### PR TITLE
build: adopt codex as default cli agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Always check for native modules or options first: Home Manager, NixOS, nix-darwin, or any other flake inputs in the project. If a native option exists, prefer enabling it. If not, look for another published Nix flake that provides the functionality. Only fall back to custom Nix code or package definitions when no existing module or flake solves the problem.

--- a/ops/nix/rafiq.nix
+++ b/ops/nix/rafiq.nix
@@ -63,8 +63,17 @@ in
         programs = {
           codex = {
             enable = true;
-            settings.features = {
-              web_search_request = true;
+            settings = {
+              features.web_search_request = true;
+              model = "gpt-5.1-codex-max"; # Little blurb to get it to use a temporary better model
+              notice."hide_gpt-5.1-codex-max_migration_prompt" = true; # ^
+              projects = {
+                "/Users/rafiq".trust_level = "untrusted";
+                "/Users/rafiq/repos".trust_level = "trusted";
+                # "/Users/rafiq/repos/alphastory".trust_level = "trusted";
+                # "/Users/rafiq/repos/pinbreak".trust_level = "trusted";
+                # "/Users/rafiq/Downloads".trust_level = "untrusted";
+              };
             };
             # Note: Don't remove or modify the following without STRICT research.
             custom-instructions = ''

--- a/ops/nix/rafiq.nix
+++ b/ops/nix/rafiq.nix
@@ -61,6 +61,16 @@ in
           };
         };
         programs = {
+          codex = {
+            enable = true;
+            settings.features = {
+              web_search_request = true;
+            };
+            # Note: Don't remove or modify the following without STRICT research.
+            custom-instructions = ''
+              I should really remember that I have access to web search, and I should really try and use web search for anything that might be outdated or underrepresented in our dataset, which if the user is asking me, is probably true. I should verify syntax by reading language docs, confirm options by reading api references, and keep in mind the whole context by investigating and keeping in context our own codebase.
+            '';
+          };
           carapace.enable = true;
           zoxide.enable = true;
           nix-index.enable = true;


### PR DESCRIPTION
cli agents ive used so far have kind of sucked in comparison to getting context and just asking chatgpt ui. i like chatgpt model for coding. i couldnt use it cos codex cli ui sucked dick. now it is actually very good and auth is smoother (or i have lower tolerance for annoyance). ive been using it stock for a week with brew (imperatively) and its time to give it a go but properly thus this PR. seems to me like CLI agents are at a point now where its no longer early adopter and now more like first to an objectively force multiplying thing. may be good to promote them from a shitty tool to a core part of my workflow shitty tool that i now have to unshittify
