### PR TITLE
build(nix-on-droid): add home-manager to my phone

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,7 @@
+nod:
+  just nice
+  nix-on-droid switch --flake .#perseus
+
 rb:
   just nice
   just check
@@ -11,7 +15,11 @@ lint: lint-lua lint-nix
 test: test-nix
 
 format-gha:
-  zizmor . --gh-token $(gh auth token) --fix
+  # if not authed to github just skip
+  @TOKEN=$(gh auth token 2>/dev/null || true); \
+  if [ -n "$TOKEN" ]; then \
+    zizmor . --gh-token "$TOKEN" --fix; \
+  fi
 
 format-lua:
   stylua .

--- a/flake.lock
+++ b/flake.lock
@@ -133,6 +133,27 @@
         "type": "github"
       }
     },
+    "home-manager_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-on-droid",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709445365,
+        "narHash": "sha256-DVv6nd9FQBbMWbOmhq0KVqmlc3y3FMSYl49UXmMcO+0=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "4de84265d7ec7634a69ba75028696d74de9a44a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "homebrew-cask": {
       "flake": false,
       "locked": {
@@ -252,6 +273,29 @@
         "type": "github"
       }
     },
+    "nix-formatter-pack": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-on-droid",
+          "nixpkgs"
+        ],
+        "nmd": "nmd",
+        "nmt": "nmt"
+      },
+      "locked": {
+        "lastModified": 1705252799,
+        "narHash": "sha256-HgSTREh7VoXjGgNDwKQUYcYo13rPkltW7IitHrTPA5c=",
+        "owner": "Gerschtli",
+        "repo": "nix-formatter-pack",
+        "rev": "2de39dedd79aab14c01b9e2934842051a160ffa5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Gerschtli",
+        "repo": "nix-formatter-pack",
+        "type": "github"
+      }
+    },
     "nix-homebrew": {
       "inputs": {
         "brew-src": "brew-src"
@@ -287,6 +331,32 @@
       "original": {
         "owner": "nix-community",
         "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
+    "nix-on-droid": {
+      "inputs": {
+        "home-manager": "home-manager_2",
+        "nix-formatter-pack": "nix-formatter-pack",
+        "nixpkgs": [
+          "nixpkgs-2405"
+        ],
+        "nixpkgs-docs": "nixpkgs-docs",
+        "nixpkgs-for-bootstrap": "nixpkgs-for-bootstrap",
+        "nmd": "nmd_2"
+      },
+      "locked": {
+        "lastModified": 1720396533,
+        "narHash": "sha256-UFzk/hZWO1VkciIO5UPaSpJN8s765wsngUSvtJM6d5Q=",
+        "owner": "nix-community",
+        "repo": "nix-on-droid",
+        "rev": "f3d3b8294039f2f9a8fb7ea82c320f29c6b0fe25",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-24.05",
+        "repo": "nix-on-droid",
         "type": "github"
       }
     },
@@ -400,6 +470,38 @@
         "type": "github"
       }
     },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-docs": {
+      "locked": {
+        "lastModified": 1705957679,
+        "narHash": "sha256-Q8LJaVZGJ9wo33wBafvZSzapYsjOaNjP/pOnSiKVGHY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9a333eaa80901efe01df07eade2c16d183761fa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-firefox-darwin": {
       "inputs": {
         "nixpkgs": "nixpkgs_3"
@@ -415,6 +517,22 @@
       "original": {
         "owner": "bandithedoge",
         "repo": "nixpkgs-firefox-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs-for-bootstrap": {
+      "locked": {
+        "lastModified": 1720244366,
+        "narHash": "sha256-WrDV0FPMVd2Sq9hkR5LNHudS3OSMmUrs90JUTN+MXpA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "49ee0e94463abada1de470c9c07bfc12b36dcf40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "49ee0e94463abada1de470c9c07bfc12b36dcf40",
         "type": "github"
       }
     },
@@ -482,6 +600,60 @@
         "type": "github"
       }
     },
+    "nmd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1666190571,
+        "narHash": "sha256-Z1hc7M9X6L+H83o9vOprijpzhTfOBjd0KmUTnpHAVjA=",
+        "owner": "rycee",
+        "repo": "nmd",
+        "rev": "b75d312b4f33bd3294cd8ae5c2ca8c6da2afc169",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmd",
+        "type": "gitlab"
+      }
+    },
+    "nmd_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-on-droid",
+          "nixpkgs-docs"
+        ],
+        "scss-reset": "scss-reset"
+      },
+      "locked": {
+        "lastModified": 1705050560,
+        "narHash": "sha256-x3zzcdvhJpodsmdjqB4t5mkVW22V3wqHLOun0KRBzUI=",
+        "owner": "~rycee",
+        "repo": "nmd",
+        "rev": "66d9334933119c36f91a78d565c152a4fdc8d3d3",
+        "type": "sourcehut"
+      },
+      "original": {
+        "owner": "~rycee",
+        "repo": "nmd",
+        "type": "sourcehut"
+      }
+    },
+    "nmt": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648075362,
+        "narHash": "sha256-u36WgzoA84dMVsGXzml4wZ5ckGgfnvS0ryzo/3zn/Pc=",
+        "owner": "rycee",
+        "repo": "nmt",
+        "rev": "d83601002c99b78c89ea80e5e6ba21addcfe12ae",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmt",
+        "type": "gitlab"
+      }
+    },
     "nvf": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -515,9 +687,11 @@
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nix-index-database": "nix-index-database",
+        "nix-on-droid": "nix-on-droid",
         "nix-rosetta-builder": "nix-rosetta-builder",
         "nixos-generators": "nixos-generators_2",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-firefox-darwin": "nixpkgs-firefox-darwin",
         "nvf": "nvf",
         "sops-nix": "sops-nix",
@@ -542,6 +716,22 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "scss-reset": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631450058,
+        "narHash": "sha256-muDlZJPtXDIGevSEWkicPP0HQ6VtucbkMNygpGlBEUM=",
+        "owner": "andreymatin",
+        "repo": "scss-reset",
+        "rev": "0cf50e27a4e95e9bb5b1715eedf9c54dee1a5a91",
+        "type": "github"
+      },
+      "original": {
+        "owner": "andreymatin",
+        "repo": "scss-reset",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,11 @@
       url = "github:nix-community/nixos-generators";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nixpkgs-2405.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nix-on-droid = {
+      url = "github:nix-community/nix-on-droid/release-24.05";
+      inputs.nixpkgs.follows = "nixpkgs-2405";
+    };
     nix-rosetta-builder = {
       url = "github:cpick/nix-rosetta-builder";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/builders/_templates/nix-on-droid-basic/flake.nix
+++ b/nix/builders/_templates/nix-on-droid-basic/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "Basic example of Nix-on-Droid system config.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+
+    nix-on-droid = {
+      url = "github:nix-community/nix-on-droid/release-24.05";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, nix-on-droid }: {
+
+    nixOnDroidConfigurations.default = nix-on-droid.lib.nixOnDroidConfiguration {
+      pkgs = import nixpkgs { system = "aarch64-linux"; };
+      modules = [ ./nix-on-droid.nix ];
+    };
+
+  };
+}

--- a/nix/builders/_templates/nix-on-droid-basic/flake.nix
+++ b/nix/builders/_templates/nix-on-droid-basic/flake.nix
@@ -10,12 +10,17 @@
     };
   };
 
-  outputs = { self, nixpkgs, nix-on-droid }: {
+  outputs =
+    {
+      nixpkgs,
+      nix-on-droid,
+    }:
+    {
 
-    nixOnDroidConfigurations.default = nix-on-droid.lib.nixOnDroidConfiguration {
-      pkgs = import nixpkgs { system = "aarch64-linux"; };
-      modules = [ ./nix-on-droid.nix ];
+      nixOnDroidConfigurations.default = nix-on-droid.lib.nixOnDroidConfiguration {
+        pkgs = import nixpkgs { system = "aarch64-linux"; };
+        modules = [ ./nix-on-droid.nix ];
+      };
+
     };
-
-  };
 }

--- a/nix/builders/_templates/nix-on-droid-basic/nix-on-droid.nix
+++ b/nix/builders/_templates/nix-on-droid-basic/nix-on-droid.nix
@@ -1,4 +1,7 @@
-{ config, lib, pkgs, ... }:
+{
+  pkgs,
+  ...
+}:
 
 {
   # Simply install just the packages
@@ -40,6 +43,6 @@
 
   # Set your time zone
   #time.timeZone = "Europe/Berlin";
-  
+
   android-integration.termux-setup-storage.enable = true;
 }

--- a/nix/builders/_templates/nix-on-droid-basic/nix-on-droid.nix
+++ b/nix/builders/_templates/nix-on-droid-basic/nix-on-droid.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+{
+  # Simply install just the packages
+  environment.packages = with pkgs; [
+    # User-facing stuff that you really really want to have
+    vim # or some other editor, e.g. nano or neovim
+
+    # Some common stuff that people expect to have
+    #procps
+    #killall
+    #diffutils
+    #findutils
+    #utillinux
+    #tzdata
+    #hostname
+    #man
+    #gnugrep
+    #gnupg
+    #gnused
+    #gnutar
+    #bzip2
+    #gzip
+    #xz
+    #zip
+    #unzip
+    git
+  ];
+
+  # Backup etc files instead of failing to activate generation if a file already exists in /etc
+  environment.etcBackupExtension = ".bak";
+
+  # Read the changelog before changing this value
+  system.stateVersion = "24.05";
+
+  # Set up nix for flakes
+  nix.extraOptions = ''
+    experimental-features = nix-command flakes
+  '';
+
+  # Set your time zone
+  #time.timeZone = "Europe/Berlin";
+  
+  android-integration.termux-setup-storage.enable = true;
+}

--- a/nix/builders/nixOnDroidConfigurations.nix
+++ b/nix/builders/nixOnDroidConfigurations.nix
@@ -1,0 +1,20 @@
+# Constructs nixOnDroidConfigurations from config.flake.modules.nixOnDroid.{default, hostName},
+# where hostName is the defined name of the machine
+{ inputs, config, ... }:
+let
+  cfg = config.flake;
+  inherit (builtins) mapAttrs;
+in
+{
+  config.flake.nixOnDroidConfigurations = mapAttrs (
+    hostName: _:
+    inputs.nix-on-droid.lib.nixOnDroidConfiguration {
+      # specialArgs = { inherit hostName; };
+      pkgs = import inputs.nixpkgs-2405 { system = "aarch64-linux"; };
+      modules = [
+        (cfg.modules.droid.default or { })
+        (cfg.modules.droid.${hostName} or { })
+      ];
+    }
+  ) cfg.hosts.droid;
+}

--- a/nix/options/hosts/droid.nix
+++ b/nix/options/hosts/droid.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+let
+  inherit (lib.options) mkOption;
+  inherit (lib.types) attrsOf raw;
+in
+{
+  options.flake.hosts.droid = mkOption {
+    type = attrsOf raw;
+    default = { };
+    description = "Attribute set where each member is a android host.";
+  };
+  config.flake.modules.droid.default = {
+    # Backup etc files instead of failing to activate generation if a file already exists in /etc
+    environment.etcBackupExtension = ".bak";
+
+    # Read the changelog before changing this value
+    system.stateVersion = "24.05";
+
+    nix.extraOptions = ''
+      experimental-features = nix-command flakes
+    '';
+
+    android-integration.termux-setup-storage.enable = true;
+  };
+}

--- a/nix/perseus.nix
+++ b/nix/perseus.nix
@@ -1,0 +1,32 @@
+{ inputs, ... }:
+{
+  config.flake = {
+    nixOnDroidConfigurations.perseus = inputs.nix-on-droid.lib.nixOnDroidConfiguration {
+      pkgs = import inputs.nixpkgs-2405 { system = "aarch64-linux"; };
+      modules = [
+        (
+          { pkgs, ... }:
+          {
+            environment.packages = with pkgs; [
+              neovim
+              git
+            ];
+
+            # Backup etc files instead of failing to activate generation if a file already exists in /etc
+            environment.etcBackupExtension = ".bak";
+
+            # Read the changelog before changing this value
+            system.stateVersion = "24.05";
+
+            nix.extraOptions = ''
+              experimental-features = nix-command flakes
+            '';
+
+            android-integration.termux-setup-storage.enable = true;
+            android-integration.unsupported.enable = true;
+          }
+        )
+      ];
+    };
+  };
+}

--- a/nix/perseus.nix
+++ b/nix/perseus.nix
@@ -10,6 +10,7 @@
             environment.packages = with pkgs; [
               neovim
               git
+              openssh
             ];
 
             # Backup etc files instead of failing to activate generation if a file already exists in /etc

--- a/nix/perseus.nix
+++ b/nix/perseus.nix
@@ -1,33 +1,14 @@
-{ inputs, ... }:
 {
   config.flake = {
-    nixOnDroidConfigurations.perseus = inputs.nix-on-droid.lib.nixOnDroidConfiguration {
-      pkgs = import inputs.nixpkgs-2405 { system = "aarch64-linux"; };
-      modules = [
-        (
-          { pkgs, ... }:
-          {
-            environment.packages = with pkgs; [
-              neovim
-              git
-              openssh
-            ];
-
-            # Backup etc files instead of failing to activate generation if a file already exists in /etc
-            environment.etcBackupExtension = ".bak";
-
-            # Read the changelog before changing this value
-            system.stateVersion = "24.05";
-
-            nix.extraOptions = ''
-              experimental-features = nix-command flakes
-            '';
-
-            android-integration.termux-setup-storage.enable = true;
-            android-integration.unsupported.enable = true;
-          }
-        )
-      ];
-    };
+    hosts.droid.perseus = { };
+    modules.droid.perseus =
+      { pkgs, ... }:
+      {
+        environment.packages = with pkgs; [
+          neovim
+          git
+          openssh
+        ];
+      };
   };
 }

--- a/nix/systems.nix
+++ b/nix/systems.nix
@@ -1,6 +1,7 @@
 {
   systems = [
     "aarch64-darwin" # alpha
+    "aarch64-linux" # perseus
     "x86_64-linux" # github action runner
   ];
 }


### PR DESCRIPTION
the goal for this PR is to get my home env on my android phone via the nix-on-droid app.

done:
- installed the app
- bootstrapped the initial flake to provide git, openssh, and termux-setup-storage
- cloned this git repo
- integrated the initial flake as a nixOnDroidConfigurations output