### PR TITLE
docs(firefox): add explanation behind nixpkgs firefox nightly input

### DIFF
--- a/nix/builders/allowedUnfreePackages.nix
+++ b/nix/builders/allowedUnfreePackages.nix
@@ -1,5 +1,7 @@
-# Takes config.flake.allowedUnfreePackages, a list of strings, and makes them all allowed
-# system wide
+# Collects every string in config.flake.allowedUnfreePackages (merged from any nix/*.nix file via flake-parts)
+# and feeds nixpkgs.config.allowUnfreePredicate (the function nixpkgs calls to decide if an unfree package
+# is allowed) with a predicate that returns true when the package name is in that merged list. On Darwin
+# this lets us allow overlays like firefox-bin (unfree) without duplicating logic per host/user.
 { lib, config, ... }:
 let
   cfg = config.flake;

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -24,6 +24,7 @@ in
         {
           users.users.rafiq.shell = pkgs.fish;
           programs.fish.enable = true;
+          # macOS upstream Firefox in nixpkgs is broken; this overlay provides the working firefox-bin build for Darwin.
           nixpkgs.overlays = [ inputs.nixpkgs-firefox-darwin.overlay ];
           nix.settings.extra-substituters = [ "https://yazi.cachix.org" ];
           nix.settings.extra-trusted-public-keys = [
@@ -109,7 +110,8 @@ in
             };
             firefox = {
               enable = true;
-              package = if pkgs.stdenv.isDarwin then null else pkgs.firefox; # throws error on darwin
+              # HM’s firefox module errors on Darwin when a package is set; keep null on macOS and install via home.packages.
+              package = if pkgs.stdenv.isDarwin then null else pkgs.firefox;
             };
             git = {
               enable = true;


### PR DESCRIPTION
originally, i checked out this branch to add [making firefox's fullscreen conform to its window size](https://github.com/rrvsh/til/blob/77874bae3e8afeb3b31a0bc95fa1a3113a49fab0/firefox/conform-fullscreen.md) declarative in nix. i realised 1. i dont need to do that because its not something i want declarative anyway, i want it to be imperative, and 2. it requires more thought - perhaps part of a larger think about browsers
