### PR TITLE
feat(home-manager): backup linked files once if they already exist during activation

### DIFF
--- a/nix/options/users/_build_darwin_users.nix
+++ b/nix/options/users/_build_darwin_users.nix
@@ -26,16 +26,21 @@ in
           openssh.authorizedKeys.keys = [ userConfig.pubkey ];
         }
       );
-      home-manager.useGlobalPkgs = true;
-      home-manager.users = mapToUsers (
-        username: _: {
-          imports = [ cfg.modules.homeManager.${username} ];
-          home = {
-            inherit username;
-            homeDirectory = config.users.users.${username}.home;
-            stateVersion = "25.11";
-          };
-        }
-      );
+      home-manager = {
+        # keep only one backup of files
+        backupFileExtension = "bak";
+        overwriteBackup = true;
+        useGlobalPkgs = true;
+        users = mapToUsers (
+          username: _: {
+            imports = [ cfg.modules.homeManager.${username} ];
+            home = {
+              inherit username;
+              homeDirectory = config.users.users.${username}.home;
+              stateVersion = "25.11";
+            };
+          }
+        );
+      };
     };
 }


### PR DESCRIPTION
Please do one of the following:
- In standalone mode, use 'home-manager switch -b backup' to back up files automatically.
- When used as a NixOS or nix-darwin module, set either
  - 'home-manager.backupFileExtension', or
  - 'home-manager.backupCommand',
  to move the file to a new location in the same directory, or run a custom command.
- Set 'force = true' on the related file options to forcefully overwrite the files below. eg. 'xdg.configFile."mimeapps.list".force = true'
Existing file '/Users/rafiq/.codex/config.toml' would be clobbered
Error:
   0: Darwin activation failed
   1: Activating configuration (