### PR TITLE
refactor(site): move app into module and set up index and blog routes

### DIFF
--- a/rs/site/src/app/mod.rs
+++ b/rs/site/src/app/mod.rs
@@ -1,8 +1,18 @@
-use axum::routing::get;
-
 pub mod routes;
 pub mod settings;
 
-pub fn build() -> axum::Router {
-    axum::Router::new().route("/", get(routes::hello))
+pub async fn serve() {
+    let settings = settings::AppSettings::from_env();
+    let listener = tokio::net::TcpListener::bind(settings.addr).await.unwrap();
+    let router = routes::build_router();
+    axum::serve(listener, router)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .unwrap();
+}
+
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to install Ctrl+C handler");
 }

--- a/rs/site/src/app/routes.rs
+++ b/rs/site/src/app/routes.rs
@@ -6,21 +6,28 @@ use axum::{
 };
 
 pub fn build_router() -> axum::Router {
-    axum::Router::new().route("/", get(hello))
+    axum::Router::new()
+        .route("/", get(index_get))
+        .route("/blog", get(blog_index_get))
 }
 
 #[derive(Template)]
-#[template(path = "hello.html")]
-struct HelloTemplate {
-    name: String,
+#[template(path = "index.html")]
+struct IndexTemplate {}
+
+pub async fn index_get() -> Result<Response, StatusCode> {
+    IndexTemplate {}.render().map_or_else(
+        |_| Err(StatusCode::INTERNAL_SERVER_ERROR),
+        |rendered| Ok(Html(rendered).into_response()),
+    )
 }
 
-pub async fn hello() -> Result<Response, StatusCode> {
-    HelloTemplate {
-        name: "world".to_string(),
-    }
-    .render()
-    .map_or_else(
+#[derive(Template)]
+#[template(path = "blog/index.html")]
+struct BlogIndexTemplate {}
+
+pub async fn blog_index_get() -> Result<Response, StatusCode> {
+    BlogIndexTemplate {}.render().map_or_else(
         |_| Err(StatusCode::INTERNAL_SERVER_ERROR),
         |rendered| Ok(Html(rendered).into_response()),
     )

--- a/rs/site/src/app/routes.rs
+++ b/rs/site/src/app/routes.rs
@@ -2,7 +2,12 @@ use askama::Template;
 use axum::{
     http::StatusCode,
     response::{Html, IntoResponse, Response},
+    routing::get,
 };
+
+pub fn build_router() -> axum::Router {
+    axum::Router::new().route("/", get(hello))
+}
 
 #[derive(Template)]
 #[template(path = "hello.html")]

--- a/rs/site/src/main.rs
+++ b/rs/site/src/main.rs
@@ -2,17 +2,5 @@ mod app;
 
 #[tokio::main]
 async fn main() {
-    let settings = app::settings::AppSettings::from_env();
-    let app = app::build();
-    let listener = tokio::net::TcpListener::bind(settings.addr).await.unwrap();
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await
-        .unwrap();
-}
-
-async fn shutdown_signal() {
-    tokio::signal::ctrl_c()
-        .await
-        .expect("failed to install Ctrl+C handler");
+    app::serve().await;
 }

--- a/rs/site/templates/base.html
+++ b/rs/site/templates/base.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+
+  <body>
+    <header>
+      {% block header %}
+      {% endblock %}
+    </header>
+    <main>
+      {% block content %}
+      {% endblock %}
+    </main>
+  </body>
+</html>

--- a/rs/site/templates/base.html
+++ b/rs/site/templates/base.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <style>
+      body {
+        background: black;
+        color: white;
+      }
+    </style>
   </head>
 
   <body>

--- a/rs/site/templates/blog/index.html
+++ b/rs/site/templates/blog/index.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>blog index page</h1>
+  <p>currently under construction!</p>
+  <p>follow progress <a href="https://github.com/rrvsh/tools">here</a></p>
+{% endblock %}

--- a/rs/site/templates/hello.html
+++ b/rs/site/templates/hello.html
@@ -1,1 +1,0 @@
-Hello, {{ name }}!

--- a/rs/site/templates/index.html
+++ b/rs/site/templates/index.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>rrv.sh index page</h1>
+  <p>currently under construction!</p>
+  <p>follow progress <a href="https://github.com/rrvsh/tools">here</a></p>
+{% endblock %}


### PR DESCRIPTION
Getting a static directory into the docker image takes a lot of work. This doesn't bode well for getting the markdown files into the image, but we solve this for now with a `<style>` tag.