### PR TITLE
feat(site): render articles by url path and slug

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+PUBLISH=~/publish

--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,1 @@
-SITE_CONTENT_DIR=~/publish
+SITE_CONTENT_DIR=/Users/rafiq/publish

--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,1 @@
-PUBLISH=~/publish
+SITE_CONTENT_DIR=~/publish

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 use flake
+dotenv

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
-# generated files
-
 result
 .direnv
-*.img*
-*.qcow2
-keys/
-
-# developer choice
-**tmp**
+.env

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,9 @@
+watch-rs:
+  bacon run -- --manifest-path rs/Cargo.toml --package site
+
+watch-clippy:
+  bacon clippy -- --manifest-path rs/Cargo.toml --package site
+
 setup:
   cp .env.template .env
   aws sts get-caller-identity > /dev/null 2>&1 || aws configure

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,5 @@
 setup:
+  cp .env.template .env
   aws sts get-caller-identity > /dev/null 2>&1 || aws configure
   colima status > /dev/null 2>&1 || colima start
 

--- a/nix/builders/devShells.nix
+++ b/nix/builders/devShells.nix
@@ -26,6 +26,7 @@
           clippy
           rustc
           rustfmt
+          bacon
 
           # docker
           docker

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "askama"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +157,37 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -190,6 +240,25 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
 ]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "http"
@@ -274,6 +343,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +394,28 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "markdown"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
+dependencies = [
+ "unicode-id",
+]
+
+[[package]]
+name = "markdown-frontmatter"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7430fd66a1ba512543425144850284f8c821bc1e3e35cd6c13684823815d707a"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "matchit"
@@ -404,6 +521,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +548,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -428,6 +571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -475,6 +619,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +637,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -502,6 +668,10 @@ version = "0.1.0-alpha"
 dependencies = [
  "askama",
  "axum",
+ "ignore",
+ "markdown",
+ "markdown-frontmatter",
+ "serde",
  "tokio",
 ]
 
@@ -539,6 +709,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +755,45 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
@@ -615,16 +844,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-id"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows-link"

--- a/rs/site/Cargo.toml
+++ b/rs/site/Cargo.toml
@@ -12,6 +12,10 @@ categories = ["site"]
 [dependencies]
 askama = "0.15.1"
 axum = "0.8.8"
+ignore = "0.4.25"
+markdown = "1.0.0"
+markdown-frontmatter = { version = "0.4.0", features = ["yaml"] }
+serde = "1.0.228"
 tokio = { version = "1.49.0", features = ["full"] }
 
 [lints.clippy]

--- a/rs/site/src/app/mod.rs
+++ b/rs/site/src/app/mod.rs
@@ -3,8 +3,8 @@ pub mod settings;
 
 pub async fn serve() {
     let settings = settings::AppSettings::from_env();
-    let listener = tokio::net::TcpListener::bind(settings.addr).await.unwrap();
-    let router = routes::build_router();
+    let listener = tokio::net::TcpListener::bind(&settings.addr).await.unwrap();
+    let router = routes::build_router(settings);
     axum::serve(listener, router)
         .with_graceful_shutdown(shutdown_signal())
         .await

--- a/rs/site/src/app/routes.rs
+++ b/rs/site/src/app/routes.rs
@@ -1,16 +1,18 @@
+use crate::app::settings::AppSettings;
 use askama::Template;
 use axum::{
-    extract::Path,
+    extract::{Path, State},
     http::StatusCode,
     response::{Html, IntoResponse, Response},
     routing::get,
 };
 
-pub fn build_router() -> axum::Router {
+pub fn build_router(settings: AppSettings) -> axum::Router {
     axum::Router::new()
         .route("/", get(index_get))
         .route("/blog", get(blog_index_get))
         .route("/{year}/{month}/{day}/{slug}", get(article_get))
+        .with_state(settings)
 }
 
 #[derive(Template)]
@@ -43,9 +45,14 @@ struct ArticleTemplate {
 
 pub async fn article_get(
     Path((year, month, day, slug)): Path<(i32, i32, i32, String)>,
+    State(settings): State<AppSettings>,
 ) -> Result<Response, StatusCode> {
-    let content = format!("{year}-{month}-{day}-{slug}");
-    ArticleTemplate { content }.render().map_or_else(
+    let AppSettings { content_dir, .. } = settings;
+    ArticleTemplate {
+        content: format!("{content_dir}/{year}/{month}/{day}/{slug}"),
+    }
+    .render()
+    .map_or_else(
         |_| Err(StatusCode::INTERNAL_SERVER_ERROR),
         |rendered| Ok(Html(rendered).into_response()),
     )

--- a/rs/site/src/app/routes.rs
+++ b/rs/site/src/app/routes.rs
@@ -6,6 +6,10 @@ use axum::{
     response::{Html, IntoResponse, Response},
     routing::get,
 };
+use ignore::{DirEntry, WalkBuilder};
+use markdown::to_html;
+use serde::Deserialize;
+use std::fs::read_to_string;
 
 pub fn build_router(settings: AppSettings) -> axum::Router {
     axum::Router::new()
@@ -43,17 +47,67 @@ struct ArticleTemplate {
     content: String,
 }
 
+#[derive(Deserialize)]
+struct ArticleFrontmatter {
+    slug: String,
+}
+
+fn is_requested_article(entry: &DirEntry, slug: &str) -> bool {
+    let file_extension = entry
+        .path()
+        .extension()
+        .map(|osstr| osstr.to_str().expect("Invalid UTF-8!"));
+    if Some("md") == file_extension {
+        let file_content = read_to_string(entry.path()).expect("Error reading file to string!");
+        let (frontmatter, _) = markdown_frontmatter::parse::<ArticleFrontmatter>(&file_content)
+            .expect("Error parsing frontmatter!");
+        frontmatter.slug == slug
+    } else {
+        false
+    }
+}
+
+fn get_first_file_path_by_slug(folder_path: &str, slug: &str) -> Option<String> {
+    let matching_entries = WalkBuilder::new(folder_path)
+        .max_depth(Some(1))
+        .build()
+        .filter_map(|entry| entry.ok().filter(|entry| is_requested_article(entry, slug)))
+        .collect::<Vec<DirEntry>>();
+    if matching_entries.len() == 1 {
+        Some(
+            matching_entries
+                .first()
+                .expect("Error getting dir entry!")
+                .path()
+                .to_str()
+                .expect("Invalid UTF-8")
+                .to_string(),
+        )
+    } else {
+        None
+    }
+}
+
 pub async fn article_get(
     Path((year, month, day, slug)): Path<(i32, i32, i32, String)>,
     State(settings): State<AppSettings>,
 ) -> Result<Response, StatusCode> {
     let AppSettings { content_dir, .. } = settings;
-    ArticleTemplate {
-        content: format!("{content_dir}/{year}/{month}/{day}/{slug}"),
-    }
-    .render()
-    .map_or_else(
-        |_| Err(StatusCode::INTERNAL_SERVER_ERROR),
-        |rendered| Ok(Html(rendered).into_response()),
+    let folder_path = format!("{content_dir}/{year}/{month}/{day}");
+    get_first_file_path_by_slug(&folder_path, &slug).map_or_else(
+        || Err(StatusCode::NOT_FOUND),
+        |file_path| {
+            let file_content = read_to_string(file_path).expect("Error reading file!");
+            let (_, body) = markdown_frontmatter::parse::<ArticleFrontmatter>(&file_content)
+                .expect("Error parsing frontmatter!");
+            ArticleTemplate {
+                content: to_html(body),
+            }
+            .render()
+            .map_or_else(
+                |_| Err(StatusCode::INTERNAL_SERVER_ERROR),
+                |rendered| Ok(Html(rendered).into_response()),
+            )
+        },
     )
 }

--- a/rs/site/src/app/routes.rs
+++ b/rs/site/src/app/routes.rs
@@ -1,5 +1,6 @@
 use askama::Template;
 use axum::{
+    extract::Path,
     http::StatusCode,
     response::{Html, IntoResponse, Response},
     routing::get,
@@ -9,6 +10,7 @@ pub fn build_router() -> axum::Router {
     axum::Router::new()
         .route("/", get(index_get))
         .route("/blog", get(blog_index_get))
+        .route("/{year}/{month}/{day}/{slug}", get(article_get))
 }
 
 #[derive(Template)]
@@ -28,6 +30,22 @@ struct BlogIndexTemplate {}
 
 pub async fn blog_index_get() -> Result<Response, StatusCode> {
     BlogIndexTemplate {}.render().map_or_else(
+        |_| Err(StatusCode::INTERNAL_SERVER_ERROR),
+        |rendered| Ok(Html(rendered).into_response()),
+    )
+}
+
+#[derive(Template)]
+#[template(path = "article.html")]
+struct ArticleTemplate {
+    content: String,
+}
+
+pub async fn article_get(
+    Path((year, month, day, slug)): Path<(i32, i32, i32, String)>,
+) -> Result<Response, StatusCode> {
+    let content = format!("{year}-{month}-{day}-{slug}");
+    ArticleTemplate { content }.render().map_or_else(
         |_| Err(StatusCode::INTERNAL_SERVER_ERROR),
         |rendered| Ok(Html(rendered).into_response()),
     )

--- a/rs/site/src/app/settings.rs
+++ b/rs/site/src/app/settings.rs
@@ -1,13 +1,18 @@
+#[derive(Clone)]
 pub struct AppSettings {
     pub addr: String,
+    pub content_dir: String,
 }
 
 impl AppSettings {
     pub fn from_env() -> Self {
         let host = std::env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
         let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+        let content_dir =
+            std::env::var("SITE_CONTENT_DIR").unwrap_or_else(|_| "~/publish".to_string());
         Self {
             addr: format!("{host}:{port}"),
+            content_dir,
         }
     }
 }

--- a/rs/site/src/app/settings.rs
+++ b/rs/site/src/app/settings.rs
@@ -8,8 +8,8 @@ impl AppSettings {
     pub fn from_env() -> Self {
         let host = std::env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
         let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-        let content_dir =
-            std::env::var("SITE_CONTENT_DIR").unwrap_or_else(|_| "~/publish".to_string());
+        let content_dir = std::env::var("SITE_CONTENT_DIR")
+            .unwrap_or_else(|_| "/Users/rafiq/publish".to_string());
         Self {
             addr: format!("{host}:{port}"),
             content_dir,

--- a/rs/site/templates/article.html
+++ b/rs/site/templates/article.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+  {{ content }}
+{% endblock %}

--- a/rs/site/templates/article.html
+++ b/rs/site/templates/article.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
 {% block content %}
-  {{ content }}
+  {{ content | safe }}
 {% endblock %}


### PR DESCRIPTION
Adds a `content_dir` setting with which the route `/<year>/<month>/<day>/<slug>` will render the content of the first file containing the slug in its frontmatter in `content_dir/year/month/day`.
