### PR TITLE
build(site): bake content repo into image

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -20,6 +20,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Checkout content repository
+        if: ${{ matrix.image == 'site' }}
+        timeout-minutes: 5
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          repository: rrvsh/site-content
+          path: content
+          persist-credentials: false
+
       - name: Install Nix
         timeout-minutes: 5
         uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
@@ -43,7 +52,12 @@ jobs:
       - name: Build and load container images
         timeout-minutes: 5
         run: |
-          nix develop -c docker load -i $(nix build .#packages.${{ matrix.arch == 'amd64' && 'x86_64' || 'aarch64' }}-linux.${{ matrix.image }}-image --print-out-paths)
+          IMAGE_PATH="$(
+            nix build \
+              ".#packages.${{ matrix.arch == 'amd64' && 'x86_64' || 'aarch64' }}-linux.${{ matrix.image }}-image" \
+              --print-out-paths ${{ matrix.image == 'site' && '--override-input site-content ./content' || '' }}
+          )"
+          nix develop -c docker load -i "$IMAGE_PATH"
 
       - name: Publish container images
         timeout-minutes: 5

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,7 +1,6 @@
 name: Build container image and push to container registry
 
-on:
-  push:
+on: [push, repository_dispatch]
 
 jobs:
   build-and-push:
@@ -10,6 +9,8 @@ jobs:
         arch: [amd64, arm64]
         image: [site]
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+    env:
+      LATEST: ${{ github.ref_name == 'prime' || github.event_name == 'repository_dispatch' }}
     permissions:
       contents: read
       packages: write
@@ -67,7 +68,7 @@ jobs:
 
       - name: Publish latest arch image
         timeout-minutes: 5
-        if: ${{ github.ref_name == 'prime' }}
+        if: ${{ env.LATEST }}
         run: |
           nix develop -c docker tag ${{ matrix.image }}:latest ghcr.io/rrvsh/${{ matrix.image }}:latest-${{ matrix.arch }}
           nix develop -c docker push ghcr.io/rrvsh/${{ matrix.image }}:latest-${{ matrix.arch }}
@@ -79,6 +80,8 @@ jobs:
       matrix:
         image: [site]
     runs-on: ubuntu-latest
+    env:
+      LATEST: ${{ github.ref_name == 'prime' || github.event_name == 'repository_dispatch' }}
     permissions:
       packages: write
     steps:
@@ -102,7 +105,7 @@ jobs:
 
       - name: Publish latest multi-arch manifest
         timeout-minutes: 5
-        if: ${{ github.ref_name == 'prime' }}
+        if: ${{ env.LATEST }}
         run: |
           docker manifest create ghcr.io/rrvsh/${{ matrix.image }}:latest \
             ghcr.io/rrvsh/${{ matrix.image }}:latest-amd64 \
@@ -112,7 +115,7 @@ jobs:
           docker manifest push ghcr.io/rrvsh/${{ matrix.image }}:latest
 
   redeploy-ecs-service:
-    if: github.ref_name == 'prime'
+    if: github.ref_name == 'prime' || github.event_name == 'repository_dispatch'
     needs: publish-multi-arch
     strategy:
       matrix:

--- a/flake.lock
+++ b/flake.lock
@@ -542,6 +542,7 @@
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-firefox-darwin": "nixpkgs-firefox-darwin",
         "nvf": "nvf",
+        "site-content": "site-content",
         "sops-nix": "sops-nix",
         "yazi": "yazi"
       }
@@ -565,6 +566,19 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "type": "github"
+      }
+    },
+    "site-content": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768603887,
+        "narHash": "sha256-nlyESfJ0rYX0HRHYpai1oxp8U57tF9yUBPwzwUwzEkE=",
+        "path": "/Users/rafiq/publish",
+        "type": "path"
+      },
+      "original": {
+        "path": "/Users/rafiq/publish",
+        "type": "path"
       }
     },
     "sops-nix": {

--- a/flake.lock
+++ b/flake.lock
@@ -571,14 +571,17 @@
     "site-content": {
       "flake": false,
       "locked": {
-        "lastModified": 1768603887,
-        "narHash": "sha256-nlyESfJ0rYX0HRHYpai1oxp8U57tF9yUBPwzwUwzEkE=",
-        "path": "/Users/rafiq/publish",
-        "type": "path"
+        "lastModified": 1768612608,
+        "narHash": "sha256-Dtnkhp7LMR6eswW++NROP201n7Li0obe5h0a/HeTvXE=",
+        "owner": "rrvsh",
+        "repo": "site-content",
+        "rev": "10be49dead4ca16ca7cd005f0afb6affc979f2f3",
+        "type": "github"
       },
       "original": {
-        "path": "/Users/rafiq/publish",
-        "type": "path"
+        "owner": "rrvsh",
+        "repo": "site-content",
+        "type": "github"
       }
     },
     "sops-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
       flake = false;
     };
     site-content = {
-      url = "path:/Users/rafiq/publish";
+      url = "github:rrvsh/site-content";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -42,5 +42,9 @@
       url = "github:homebrew/homebrew-cask";
       flake = false;
     };
+    site-content = {
+      url = "path:/Users/rafiq/publish";
+      flake = false;
+    };
   };
 }

--- a/nix/builders/packages.nix
+++ b/nix/builders/packages.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, inputs, ... }:
 {
   perSystem =
     { pkgs, self', ... }:
@@ -16,6 +16,7 @@
           pkgs.dockerTools.binSh
         ];
         config = {
+          Env = [ "SITE_CONTENT_DIR=${inputs.site-content}" ];
           Entrypoint = [
             "/bin/sh"
             "-c"


### PR DESCRIPTION
Adds `github:rrvsh/site-content` to the flake inputs and bakes it into the image at `$SITE_CONTENT_DIR`. Build workflow now accepts `repository_dispatch` as a trigger and builds the image with the input overridden to a checked out `site-content`.