### PR TITLE
feat(zmk): integrate ZMK keyboard firmware build

### DIFF
--- a/nix/modules/usb-automount.nix
+++ b/nix/modules/usb-automount.nix
@@ -1,0 +1,30 @@
+{
+  config.flake.modules.nixos."usb-automount" =
+    { pkgs, ... }:
+    {
+      # udisks2 provides the DBus service and udisksctl CLI used by tools such as
+      # zmk-nix's UF2 flasher. udiskie is the per-user automounter that mounts
+      # removable drives under /run/media/$USER when they appear.
+      services = {
+        udisks2.enable = true;
+        gvfs.enable = true;
+      };
+
+      environment.systemPackages = with pkgs; [
+        udisks2
+        udiskie
+        usbutils
+      ];
+
+      home-manager.sharedModules = [
+        {
+          services.udiskie = {
+            enable = true;
+            automount = true;
+            notify = true;
+            tray = "never";
+          };
+        }
+      ];
+    };
+}

--- a/nix/profiles/graphical.nix
+++ b/nix/profiles/graphical.nix
@@ -51,6 +51,7 @@ in
         firefox
         hyprland
         audio-config
+        usb-automount
       ];
       time.timeZone = "Asia/Singapore";
       security.polkit.enable = true;


### PR DESCRIPTION
## Overview

Integrate ZMK firmware build for the nice!nano_v2 + urchin + nice!view gem keyboard.

## What's Changed

- `build-zmk.yaml` workflow that builds on `zmk-config/**` changes
- `zmk-config/` with urchin keymap, west.yml, build.yaml, and board config
- `act` added to `ci-gha` devShell for local workflow testing

## Firmware

The build outputs `.uf2` files which are installed manually onto the keyboard.