### PR TITLE
chore(ci): parallelize check workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,11 +4,118 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
-  check:
+  check-gha:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+
+    steps:
+      - name: Checkout repository
+        timeout-minutes: 5
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        timeout-minutes: 5
+        uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
+        with:
+          # lets us bypass the rate limiting
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Nix dependencies
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+
+      - name: Check GitHub Actions workflow files
+        run: |
+          nix develop .#ci-gha -c zizmor .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # needed for zizmor
+
+  check-lua:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        timeout-minutes: 5
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        timeout-minutes: 5
+        uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
+        with:
+          # lets us bypass the rate limiting
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Nix dependencies
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+
+      - name: Check Lua formatting
+        run: |
+          nix develop .#ci-lua -c stylua --check .
+
+  check-nix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        timeout-minutes: 5
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        timeout-minutes: 5
+        uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
+        with:
+          # lets us bypass the rate limiting
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Nix dependencies
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+
+      - name: Check Nix formatting and lint
+        run: |
+          nix develop .#ci-nix -c bash -c "treefmt --ci && statix check && deadnix"
+
+  flake-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        timeout-minutes: 5
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        timeout-minutes: 5
+        uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
+        with:
+          # lets us bypass the rate limiting
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Nix dependencies
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+
+      - name: Run Nix flake checks
+        run: |
+          nix flake check --all-systems
+
+  check-rs:
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -43,8 +150,46 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Run all checks
+      - name: Check Rust formatting and lint
         run: |
-          nix develop -c just check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # needed for zizmor
+          nix develop .#ci-rs -c bash -c "cargo clippy --manifest-path rs/Cargo.toml --all && cargo fmt --manifest-path rs/Cargo.toml --check --all"
+
+  test-rs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        timeout-minutes: 5
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        timeout-minutes: 5
+        uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
+        with:
+          # lets us bypass the rate limiting
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Nix dependencies
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: |
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run Rust tests
+        run: |
+          nix develop .#ci-rs -c cargo test --manifest-path rs/Cargo.toml --all

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -139,12 +139,12 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: |
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
+            ~/.cache/tools/cargo/.crates.toml
+            ~/.cache/tools/cargo/.crates2.json
+            ~/.cache/tools/cargo/bin
+            ~/.cache/tools/cargo/registry/index
+            ~/.cache/tools/cargo/registry/cache
+            ~/.cache/tools/cargo/git/db
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
@@ -179,12 +179,12 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: |
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
+            ~/.cache/tools/cargo/.crates.toml
+            ~/.cache/tools/cargo/.crates2.json
+            ~/.cache/tools/cargo/bin
+            ~/.cache/tools/cargo/registry/index
+            ~/.cache/tools/cargo/registry/cache
+            ~/.cache/tools/cargo/git/db
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Check GitHub Actions workflow files
         run: |
-          nix develop .#ci-gha -c zizmor .
+          nix develop .#ci-gha -c just check-gha
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # needed for zizmor
 
@@ -62,7 +62,7 @@ jobs:
 
       - name: Check Lua formatting
         run: |
-          nix develop .#ci-lua -c stylua --check .
+          nix develop .#ci-lua -c just check-lua
 
   check-nix:
     runs-on: ubuntu-latest
@@ -87,7 +87,7 @@ jobs:
 
       - name: Check Nix formatting and lint
         run: |
-          nix develop .#ci-nix -c bash -c "treefmt --ci && statix check && deadnix"
+          nix develop .#ci-nix -c just check-nix
 
   flake-check:
     runs-on: ubuntu-latest
@@ -112,7 +112,7 @@ jobs:
 
       - name: Run Nix flake checks
         run: |
-          nix flake check --all-systems
+          nix develop .#ci-nix -c just test-nix
 
   check-rs:
     runs-on: ubuntu-latest
@@ -152,7 +152,7 @@ jobs:
 
       - name: Check Rust formatting and lint
         run: |
-          nix develop .#ci-rs -c bash -c "cargo clippy --manifest-path rs/Cargo.toml --all && cargo fmt --manifest-path rs/Cargo.toml --check --all"
+          nix develop .#ci-rs -c just check-rs
 
   test-rs:
     runs-on: ubuntu-latest
@@ -192,4 +192,4 @@ jobs:
 
       - name: Run Rust tests
         run: |
-          nix develop .#ci-rs -c cargo test --manifest-path rs/Cargo.toml --all
+          nix develop .#ci-rs -c just test-rs

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -193,3 +193,18 @@ jobs:
       - name: Run Rust tests
         run: |
           nix develop .#ci-rs -c just test-rs
+
+  check:
+    runs-on: ubuntu-latest
+    needs:
+      - check-gha
+      - check-lua
+      - check-nix
+      - flake-check
+      - check-rs
+      - test-rs
+
+    steps:
+      - name: Check workflow success
+        run: |
+          echo "All checks passed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ You should tailor your instructions to the agent, which means you do not need to
 
 You should prefer using retrieval-led reasoning either via codebase exploration or web search as opposed to relying on training data.
 
-You can git commit as `Lumen <lumen@rrv.sh>`. Don't use any git commands that involve interacting with a remote.
+You can git commit as `Lumen <lumen@rrv.sh>` using `--author "Lumen <lumen@rrvsh>"` so commits are signed. Don't use any git commands that involve interacting with a remote.
 
 ## Instructions from Agent
 

--- a/nix/outputs/devShells.nix
+++ b/nix/outputs/devShells.nix
@@ -1,74 +1,83 @@
 {
   perSystem =
     { pkgs, ... }:
+    let
+      ciInputs = {
+        gha = with pkgs; [
+          gh
+          zizmor
+        ];
+        lua = with pkgs; [
+          stylua
+        ];
+        nix = with pkgs; [
+          deadnix
+          nixfmt-tree
+          statix
+        ];
+        rs = with pkgs; [
+          cargo
+          clippy
+          rustc
+          rustfmt
+        ];
+      };
+      defaultInputs = with pkgs; [
+        # general
+        just
+
+        # nix
+        deadnix
+        nh
+        nixfmt-tree
+        statix
+
+        # lua
+        luajitPackages.luacheck
+        stylua
+
+        # gha yaml
+        gh
+        zizmor
+
+        # rs
+        cargo
+        clippy
+        rustc
+        rustfmt
+        bacon
+
+        # docker
+        docker
+        colima
+
+        # aws
+        awscli2
+
+        # terraform
+        opentofu
+      ];
+    in
     {
       devShells = {
         default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            # general
-            just
-
-            # nix
-            deadnix
-            nh
-            nixfmt-tree
-            statix
-
-            # lua
-            luajitPackages.luacheck
-            stylua
-
-            # gha yaml
-            gh
-            zizmor
-
-            # rs
-            cargo
-            clippy
-            rustc
-            rustfmt
-            bacon
-
-            # docker
-            docker
-            colima
-
-            # aws
-            awscli2
-
-            # terraform
-            opentofu
-          ];
+          buildInputs = defaultInputs;
         };
 
         ci-gha = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            gh
-            zizmor
-          ];
+          buildInputs = ciInputs.gha;
         };
 
         ci-lua = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            stylua
-          ];
+          buildInputs = ciInputs.lua;
         };
 
         ci-nix = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            deadnix
-            nixfmt-tree
-            statix
-          ];
+          buildInputs = ciInputs.nix;
         };
 
         ci-rs = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            cargo
-            clippy
-            rustc
-            rustfmt
-          ];
+          buildInputs = ciInputs.rs;
         };
       };
     };

--- a/nix/outputs/devShells.nix
+++ b/nix/outputs/devShells.nix
@@ -5,6 +5,11 @@
       ciBaseInputs = with pkgs; [
         just
       ];
+      rustShellHook = ''
+        export CARGO_HOME="$HOME/.cache/tools/cargo"
+        export RUSTUP_HOME="$HOME/.cache/tools/rustup"
+        mkdir -p "$CARGO_HOME" "$RUSTUP_HOME"
+      '';
       ciInputs = {
         gha =
           ciBaseInputs
@@ -16,6 +21,7 @@
           ciBaseInputs
           ++ (with pkgs; [
             stylua
+            luajitPackages.luacheck
           ]);
         nix =
           ciBaseInputs
@@ -33,63 +39,34 @@
             rustfmt
           ]);
       };
-      defaultInputs = with pkgs; [
-        # general
-        just
-
-        # nix
-        deadnix
-        nh
-        nixfmt-tree
-        statix
-
-        # lua
-        luajitPackages.luacheck
-        stylua
-
-        # gha yaml
-        gh
-        zizmor
-
-        # rs
-        cargo
-        clippy
-        rustc
-        rustfmt
-        bacon
-
-        # docker
-        docker
-        colima
-
-        # aws
-        awscli2
-
-        # terraform
-        opentofu
-      ];
+      defaultInputs =
+        ciInputs.nix
+        ++ ciInputs.lua
+        ++ ciInputs.gha
+        ++ ciInputs.rs
+        ++ (with pkgs; [
+          nh
+          bacon
+          docker
+          colima
+          awscli2
+          opentofu
+        ]);
+      mkShell = inputs: pkgs.mkShell { buildInputs = inputs; };
+      mkRustShell =
+        inputs:
+        pkgs.mkShell {
+          buildInputs = inputs;
+          shellHook = rustShellHook;
+        };
     in
     {
       devShells = {
-        default = pkgs.mkShell {
-          buildInputs = defaultInputs;
-        };
-
-        ci-gha = pkgs.mkShell {
-          buildInputs = ciInputs.gha;
-        };
-
-        ci-lua = pkgs.mkShell {
-          buildInputs = ciInputs.lua;
-        };
-
-        ci-nix = pkgs.mkShell {
-          buildInputs = ciInputs.nix;
-        };
-
-        ci-rs = pkgs.mkShell {
-          buildInputs = ciInputs.rs;
-        };
+        default = mkRustShell defaultInputs;
+        ci-gha = mkShell ciInputs.gha;
+        ci-lua = mkShell ciInputs.lua;
+        ci-nix = mkShell ciInputs.nix;
+        ci-rs = mkRustShell ciInputs.rs;
       };
     };
 }

--- a/nix/outputs/devShells.nix
+++ b/nix/outputs/devShells.nix
@@ -2,25 +2,36 @@
   perSystem =
     { pkgs, ... }:
     let
+      ciBaseInputs = with pkgs; [
+        just
+      ];
       ciInputs = {
-        gha = with pkgs; [
-          gh
-          zizmor
-        ];
-        lua = with pkgs; [
-          stylua
-        ];
-        nix = with pkgs; [
-          deadnix
-          nixfmt-tree
-          statix
-        ];
-        rs = with pkgs; [
-          cargo
-          clippy
-          rustc
-          rustfmt
-        ];
+        gha =
+          ciBaseInputs
+          ++ (with pkgs; [
+            gh
+            zizmor
+          ]);
+        lua =
+          ciBaseInputs
+          ++ (with pkgs; [
+            stylua
+          ]);
+        nix =
+          ciBaseInputs
+          ++ (with pkgs; [
+            deadnix
+            nixfmt-tree
+            statix
+          ]);
+        rs =
+          ciBaseInputs
+          ++ (with pkgs; [
+            cargo
+            clippy
+            rustc
+            rustfmt
+          ]);
       };
       defaultInputs = with pkgs; [
         # general

--- a/nix/outputs/devShells.nix
+++ b/nix/outputs/devShells.nix
@@ -2,42 +2,74 @@
   perSystem =
     { pkgs, ... }:
     {
-      devShells.default = pkgs.mkShell {
-        buildInputs = with pkgs; [
-          # general
-          just
+      devShells = {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # general
+            just
 
-          # nix
-          deadnix
-          nh
-          nixfmt-tree
-          statix
+            # nix
+            deadnix
+            nh
+            nixfmt-tree
+            statix
 
-          # lua
-          luajitPackages.luacheck
-          stylua
+            # lua
+            luajitPackages.luacheck
+            stylua
 
-          # gha yaml
-          gh
-          zizmor
+            # gha yaml
+            gh
+            zizmor
 
-          # rs
-          cargo
-          clippy
-          rustc
-          rustfmt
-          bacon
+            # rs
+            cargo
+            clippy
+            rustc
+            rustfmt
+            bacon
 
-          # docker
-          docker
-          colima
+            # docker
+            docker
+            colima
 
-          # aws
-          awscli2
+            # aws
+            awscli2
 
-          # terraform
-          opentofu
-        ];
+            # terraform
+            opentofu
+          ];
+        };
+
+        ci-gha = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            gh
+            zizmor
+          ];
+        };
+
+        ci-lua = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            stylua
+          ];
+        };
+
+        ci-nix = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            deadnix
+            nixfmt-tree
+            statix
+          ];
+        };
+
+        ci-rs = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            cargo
+            clippy
+            rustc
+            rustfmt
+          ];
+        };
       };
     };
 }


### PR DESCRIPTION
## Summary
- split the check workflow into parallel jobs to reduce wall time
- add slim CI devShells so nix develop only pulls required tooling
- keep all existing checks/tests (including flake check for all systems)