### PR TITLE
feat(site): serve static and content assets

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -286,6 +286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +372,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -548,6 +560,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -829,6 +851,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
+ "tower-http",
 ]
 
 [[package]]
@@ -926,6 +949,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +1017,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1073,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-id"

--- a/rs/site/Cargo.toml
+++ b/rs/site/Cargo.toml
@@ -19,6 +19,7 @@ markdown-frontmatter = { version = "0.4.0", features = ["yaml"] }
 serde = "1.0.228"
 tempfile = "3.24.0"
 tokio = { version = "1.49.0", features = ["full"] }
+tower-http = { version = "0.6.2", features = ["fs"] }
 
 [lints.clippy]
 correctness = "deny"

--- a/rs/site/src/app/controllers/mod.rs
+++ b/rs/site/src/app/controllers/mod.rs
@@ -3,10 +3,17 @@ mod index;
 
 use crate::app::state::AppState;
 use axum::routing::get;
+use std::path::PathBuf;
 use std::sync::Arc;
+use tower_http::services::ServeDir;
 
-pub fn build_router(state: Arc<AppState>) -> axum::Router {
+pub fn build_router(state: Arc<AppState>, content_dir: &str) -> axum::Router {
+    let static_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("static");
+    let assets_dir = PathBuf::from(content_dir).join("assets");
+
     axum::Router::new()
+        .nest_service("/static", ServeDir::new(static_dir))
+        .nest_service("/assets", ServeDir::new(assets_dir))
         .route("/", get(index::get))
         .route("/{year}/{month}/{day}/{slug}", get(article::get))
         .with_state(state)

--- a/rs/site/src/app/mod.rs
+++ b/rs/site/src/app/mod.rs
@@ -11,7 +11,7 @@ pub async fn serve() {
     let documents = models::document::load_documents_from_dir(&settings.content_dir);
     let state = Arc::new(state::AppState::new(documents));
     let listener = tokio::net::TcpListener::bind(&settings.addr).await.unwrap();
-    let router = controllers::build_router(state);
+    let router = controllers::build_router(state, &settings.content_dir);
     axum::serve(listener, router)
         .with_graceful_shutdown(shutdown_signal())
         .await

--- a/rs/site/static/styles.css
+++ b/rs/site/static/styles.css
@@ -1,0 +1,5 @@
+body {
+  background: black;
+  color: white;
+  text-align: center;
+}

--- a/rs/site/templates/base.html
+++ b/rs/site/templates/base.html
@@ -1,13 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <style>
-      body {
-        background: black;
-        color: white;
-        text-align: center;
-      }
-    </style>
+    <link href="/static/styles.css" rel="stylesheet" />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- serve the local static directory at /static
- serve content assets from the ingested content directory at /assets
- add tower-http fs support and pass content dir into router

## Testing
- just nice
- just check