### PR TITLE
feat(nix): allow opencode to modify temporary directories on macos and linux

### DIFF
--- a/nix/modules/opencode.nix
+++ b/nix/modules/opencode.nix
@@ -1,8 +1,18 @@
 {
   config.flake = {
     modules.homeManager.rafiq = {
-      programs.opencode.enable = true;
-      programs.opencode.enableMcpIntegration = true;
+      programs = {
+        opencode = {
+          enable = true;
+          enableMcpIntegration = true;
+          settings = {
+            permission.external_directory = {
+              "/tmp/**" = "allow";
+              "/var/folders/**" = "allow";
+            };
+          };
+        };
+      };
       home.shellAliases.oc = "opencode";
     };
   };


### PR DESCRIPTION
## Summary
- allow OpenCode to access temp worktrees under /tmp and /var/folders
- centralize opencode settings under programs.opencode to satisfy nix lint