### PR TITLE
feat(nix): add pipewire audio module

### DIFF
--- a/nix/configs/nemesis.nix
+++ b/nix/configs/nemesis.nix
@@ -84,6 +84,7 @@ in
         imports = [
           cfg.modules.nixos.hyprland
           cfg.modules.nixos.nvidia
+          cfg.modules.nixos.pipewire
           cfg.modules.nixos.steam
         ];
       }

--- a/nix/modules/hyprland.nix
+++ b/nix/modules/hyprland.nix
@@ -35,6 +35,12 @@
           portalPackage = null;
           settings = {
             "$mod" = "SUPER";
+            bind = [
+              ", XF86AudioRaiseVolume, exec, wpctl set-volume -l 1.5 @DEFAULT_AUDIO_SINK@ 5%+"
+              ", XF86AudioLowerVolume, exec, wpctl set-volume -l 1.5 @DEFAULT_AUDIO_SINK@ 5%-"
+              ", XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
+              ", XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"
+            ];
           };
         };
       };

--- a/nix/modules/pipewire.nix
+++ b/nix/modules/pipewire.nix
@@ -1,0 +1,13 @@
+{
+  config.flake.modules.nixos.pipewire = {
+    security.rtkit.enable = true;
+    services.pipewire = {
+      enable = true;
+      alsa.enable = true;
+      alsa.support32Bit = true;
+      pulse.enable = true;
+      jack.enable = true;
+      wireplumber.enable = true;
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add a PipeWire module with ALSA/Pulse/JACK enablement for NixOS
- wire the PipeWire module into the nemesis host imports
- add Hyprland audio keybinds for volume and mute controls