### PR TITLE
chore(nix): ignore direnv directories in git

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,5 +1,10 @@
 # runbook.md
 
+## stacked diffs
+
+To resign one commit per branch:
+git fetch origin prime && git rebase -i origin/prime && git commit --amend '-S' && git rebase --continue && git push -f
+
 ## generating an age key to edit sops-nix secrets
 
 ```bash

--- a/nix/modules/git.nix
+++ b/nix/modules/git.nix
@@ -3,6 +3,9 @@
     modules.homeManager.rafiq = {
       programs.git = {
         enable = true;
+        ignores = [
+          ".direnv/"
+        ];
         signing = {
           signByDefault = true;
           # this needs to be a tilde because git cant use $HOME


### PR DESCRIPTION
## Summary
- add `.direnv/` to git ignore list via home-manager config