### PR TITLE
feat(yazi): add git-commit-browser plugin

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,16 @@
+-- Luacheck configuration for Yazi plugins
+-- Yazi provides these globals in the plugin environment
+
+globals = {
+	"ya",
+	"Command",
+	"ps",
+	"ui",
+	"cx",
+}
+
+-- Don't report unused arguments (common in callbacks)
+unused_args = false
+
+-- Don't report unused variables that start with _
+ignore = { "^_" }

--- a/nix/modules/yazi.nix
+++ b/nix/modules/yazi.nix
@@ -28,6 +28,16 @@ in
           '';
         };
 
+        git-commit-browser = pkgs.stdenvNoCC.mkDerivation {
+          pname = "git-commit-browser.yazi";
+          version = "0.1.0";
+          src = cfg.paths.root + /yazi/plugins/git-commit-browser.yazi;
+          installPhase = ''
+            mkdir -p $out/share/yazi/plugins
+            cp -r . $out/share/yazi/plugins/git-commit-browser.yazi
+          '';
+        };
+
         test-yazi-plugin = pkgs.writeShellScriptBin "test-yazi-plugin" (
           lib.fileContents (cfg.paths.root + "/scripts/test-yazi-plugin.sh")
         );
@@ -49,6 +59,7 @@ in
           };
           plugins = {
             "path-from-root" = path-from-root;
+            "git-commit-browser" = "${git-commit-browser}/share/yazi/plugins/git-commit-browser.yazi";
           };
           keymap = {
             mgr.prepend_keymap = [
@@ -59,6 +70,26 @@ in
                 ];
                 run = "plugin path-from-root";
                 desc = "Copies path from git root";
+              }
+              {
+                on = "]";
+                run = "plugin git-commit-browser -- next";
+                desc = "Next commit (older)";
+              }
+              {
+                on = "[";
+                run = "plugin git-commit-browser -- prev";
+                desc = "Previous commit (newer)";
+              }
+              {
+                on = [ "g" "[" ];
+                run = "plugin git-commit-browser -- head";
+                desc = "Return to HEAD/original";
+              }
+              {
+                on = [ "g" "]" ];
+                run = "plugin git-commit-browser -- select";
+                desc = "Select commit interactively";
               }
             ];
           };

--- a/nix/modules/yazi.nix
+++ b/nix/modules/yazi.nix
@@ -82,12 +82,18 @@ in
                 desc = "Previous commit (newer)";
               }
               {
-                on = [ "g" "[" ];
+                on = [
+                  "g"
+                  "["
+                ];
                 run = "plugin git-commit-browser -- head";
                 desc = "Return to HEAD/original";
               }
               {
-                on = [ "g" "]" ];
+                on = [
+                  "g"
+                  "]"
+                ];
                 run = "plugin git-commit-browser -- select";
                 desc = "Select commit interactively";
               }

--- a/yazi/plugins/git-commit-browser.yazi/LICENSE
+++ b/yazi/plugins/git-commit-browser.yazi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/yazi/plugins/git-commit-browser.yazi/README.md
+++ b/yazi/plugins/git-commit-browser.yazi/README.md
@@ -1,0 +1,112 @@
+# git-commit-browser.yazi
+
+A Yazi plugin that enables browsing git repository history through temporary worktrees, with seamless navigation between commits and automatic cleanup.
+
+## Features
+
+- Browse git history with `]` (older) and `[` (newer) keys
+- Navigate to any commit interactively with `g]`
+- Return to HEAD with `g[`
+- Automatic worktree creation and cleanup
+- Status line integration showing current commit
+- Support for resuming from existing temp worktrees
+
+## Installation
+
+### Manual
+
+Clone this repository into your Yazi plugins directory:
+
+```bash
+git clone https://github.com/yourusername/git-commit-browser.yazi \
+  ~/.config/yazi/plugins/git-commit-browser.yazi
+```
+
+### Using Nix
+
+Add to your Yazi configuration (see Nix configuration section below).
+
+## Configuration
+
+Add to your `~/.config/yazi/keymap.toml`:
+
+```toml
+[[manager.prepend_keymap]]
+on   = "]"
+run  = "plugin git-commit-browser -- next"
+desc = "Next commit (older)"
+
+[[manager.prepend_keymap]]
+on   = "["
+run  = "plugin git-commit-browser -- prev"
+desc = "Previous commit (newer)"
+
+[[manager.prepend_keymap]]
+on   = "g["
+run  = "plugin git-commit-browser -- head"
+desc = "Return to HEAD/original"
+
+[[manager.prepend_keymap]]
+on   = "g]"
+run  = "plugin git-commit-browser -- select"
+desc = "Select commit interactively"
+```
+
+## Usage
+
+### Basic Workflow
+
+1. Open Yazi in any git repository
+2. Press `]` to create a worktree for the previous commit and navigate to it
+3. Continue pressing `]` to go further back in history
+4. Press `[` to go forward (newer commits)
+5. Press `g[` to return to HEAD/original directory
+6. Press `q` to quit Yazi (shell will cd to current directory)
+
+### Interactive Selection
+
+Press `g]` to open an interactive fzf picker showing all commits with their messages.
+
+### Status Line
+
+The plugin publishes commit information via DDS. To display it in your status line, add to your `init.lua`:
+
+```lua
+ps.sub("git-commit-browser:commit", function(info)
+  _G.git_commit_info = info
+end)
+
+Status:children_add(function(self)
+  local info = _G.git_commit_info
+  if info and info.is_temp then
+    local msg = info.message:sub(1, 30)
+    if #info.message > 30 then msg = msg .. "..." end
+    return ui.Line({
+      ui.Span(" [git: "):fg("#7aa2f7"),
+      ui.Span(info.hash):fg("#e0af68"),
+      ui.Span(' "' .. msg .. '"]'):fg("#7aa2f7"),
+    })
+  end
+  return ui.Line({})
+end, 1000, Status.LEFT)
+```
+
+## How It Works
+
+The plugin creates temporary git worktrees under `/tmp/yazi-git-browser-<hash>/` for each commit you visit. This allows you to:
+
+- View files as they existed at any point in history
+- Make changes and create branches from old commits
+- Have multiple commits accessible simultaneously
+
+Worktrees are automatically cleaned up when you return to HEAD or quit Yazi.
+
+## Requirements
+
+- Yazi >= 0.2.0
+- Git
+- fzf (for interactive commit selection)
+
+## License
+
+MIT

--- a/yazi/plugins/git-commit-browser.yazi/main.lua
+++ b/yazi/plugins/git-commit-browser.yazi/main.lua
@@ -1,0 +1,367 @@
+-- git-commit-browser.yazi
+-- Browse git repository history through temporary worktrees
+
+local state = {
+  original_repo = nil,        -- Absolute path to original .git
+  original_cwd = nil,         -- Absolute path to original working directory
+  repo_hash = nil,            -- 8-char hash of original_repo path
+  current_commit = nil,       -- Current commit hash
+  commit_list = {},           -- Ordered list of commits for navigation
+  commit_index = 1,           -- Current position in commit_list
+  worktrees = {},             -- Map: commit_hash -> worktree_path
+  quit_with_q = false,        -- Flag to skip cleanup
+  is_temp_worktree = false,   -- Whether we started in a temp worktree
+  initialized = false,        -- Whether state has been initialized
+}
+
+-- Initialize the plugin state
+local function init()
+  if state.initialized then return true end
+  
+  local cwd = ya.cwd()
+  if not cwd then
+    ya.notify({ title = "Git Commit Browser", content = "Failed to get current directory", timeout = 3 })
+    return false
+  end
+  
+  state.original_cwd = tostring(cwd)
+  
+  -- Check if we're in a temp worktree
+  local temp_pattern = "/tmp/yazi%-git%-browser%-"
+  if state.original_cwd:match(temp_pattern) then
+    state.is_temp_worktree = true
+    -- Extract repo_hash from path
+    state.repo_hash = state.original_cwd:match("/tmp/yazi%-git%-browser%-([^/]+)/")
+    
+    -- Find original repo using git worktree list
+    local output, err = Command("git")
+      :args({ "worktree", "list", "--porcelain" })
+      :cwd(state.original_cwd)
+      :output()
+    
+    if err then
+      ya.notify({ title = "Git Commit Browser", content = "Failed to find original repo: " .. tostring(err), timeout = 3 })
+      return false
+    end
+    
+    -- Parse worktree list to find the main worktree
+    for line in output.stdout:gmatch("[^\r\n]+") do
+      if line:match("^worktree ") then
+        local wt_path = line:sub(10)
+        -- Check if this is the main worktree (not our temp one)
+        if not wt_path:match(temp_pattern) then
+          state.original_repo = wt_path
+          break
+        end
+      end
+    end
+  else
+    -- We're in the original repo
+    state.is_temp_worktree = false
+    state.original_repo = state.original_cwd
+    -- Compute hash of repo path
+    local output, err = Command("sh")
+      :args({ "-c", "echo '" .. state.original_repo .. "' | sha256sum | cut -c1-8" })
+      :output()
+    if err then
+      -- Fallback to simple hash
+      local hash = 0
+      for i = 1, #state.original_repo do
+        hash = (hash * 31 + state.original_repo:byte(i)) % 100000000
+      end
+      state.repo_hash = string.format("%08x", hash)
+    else
+      state.repo_hash = output.stdout:gsub("%s+", "")
+    end
+  end
+  
+  if not state.original_repo then
+    ya.notify({ title = "Git Commit Browser", content = "Not in a git repository", timeout = 3 })
+    return false
+  end
+  
+  -- Load commit list
+  load_commits()
+  
+  state.initialized = true
+  return true
+end
+
+-- Load ordered list of commits
+local function load_commits()
+  local output, err = Command("git")
+    :args({ "log", "--format=%H", "--all" })
+    :cwd(state.original_repo)
+    :output()
+  
+  if err then
+    ya.notify({ title = "Git Commit Browser", content = "Failed to load commits: " .. tostring(err), timeout = 3 })
+    return
+  end
+  
+  state.commit_list = {}
+  for hash in output.stdout:gmatch("%x+") do
+    table.insert(state.commit_list, hash)
+  end
+  
+  -- Set current index based on current directory
+  if state.is_temp_worktree then
+    -- Extract commit from path
+    local commit = state.original_cwd:match("/([^/]+)$")
+    for i, c in ipairs(state.commit_list) do
+      if c:sub(1, 7) == commit then
+        state.commit_index = i
+        state.current_commit = c
+        break
+      end
+    end
+  else
+    -- Get HEAD commit
+    local head_output, head_err = Command("git")
+      :args({ "rev-parse", "HEAD" })
+      :cwd(state.original_repo)
+      :output()
+    
+    if not head_err then
+      state.current_commit = head_output.stdout:gsub("%s+", "")
+      for i, c in ipairs(state.commit_list) do
+        if c == state.current_commit then
+          state.commit_index = i
+          break
+        end
+      end
+    end
+  end
+  
+  -- Publish current commit info
+  publish_commit_info()
+end
+
+-- Get temp base directory
+local function get_temp_base()
+  return "/tmp/yazi-git-browser-" .. state.repo_hash
+end
+
+-- Create worktree for a commit
+local function create_worktree(commit)
+  if state.worktrees[commit] then
+    return state.worktrees[commit]
+  end
+  
+  local short_hash = commit:sub(1, 7)
+  local temp_base = get_temp_base()
+  local wt_path = temp_base .. "/" .. short_hash
+  
+  -- Create temp base if needed
+  Command("mkdir"):args({ "-p", temp_base }):output()
+  
+  -- Check if worktree already exists
+  local check_cmd = Command("test"):args({ "-d", wt_path }):output()
+  if check_cmd.status and check_cmd.status.code == 0 then
+    state.worktrees[commit] = wt_path
+    return wt_path
+  end
+  
+  -- Create worktree
+  local output, err = Command("git")
+    :args({ "worktree", "add", "--detach", wt_path, commit })
+    :cwd(state.original_repo)
+    :output()
+  
+  if err then
+    ya.notify({ title = "Git Commit Browser", content = "Failed to create worktree: " .. tostring(err), timeout = 3 })
+    return nil
+  end
+  
+  state.worktrees[commit] = wt_path
+  return wt_path
+end
+
+-- Navigate to a specific commit by index
+local function navigate_to_index(index)
+  if index < 1 or index > #state.commit_list then
+    return false
+  end
+  
+  state.commit_index = index
+  local commit = state.commit_list[index]
+  state.current_commit = commit
+  
+  local wt_path = create_worktree(commit)
+  if not wt_path then
+    return false
+  end
+  
+  -- Change directory
+  ya.emit("cd", { target = wt_path })
+  
+  -- Publish commit info for status line
+  publish_commit_info()
+  
+  return true
+end
+
+-- Navigate direction: "prev" or "next"
+local function navigate(direction)
+  if not init() then return end
+  
+  local new_index
+  if direction == "next" then
+    new_index = state.commit_index + 1
+  elseif direction == "prev" then
+    new_index = state.commit_index - 1
+  else
+    return
+  end
+  
+  if new_index < 1 then
+    ya.notify({ title = "Git Commit Browser", content = "Already at newest commit", timeout = 2 })
+    return
+  end
+  
+  if new_index > #state.commit_list then
+    ya.notify({ title = "Git Commit Browser", content = "Already at oldest commit", timeout = 2 })
+    return
+  end
+  
+  navigate_to_index(new_index)
+end
+
+-- Go to HEAD commit
+local function goto_head()
+  if not init() then return end
+  
+  -- Check if at HEAD
+  if state.commit_index == 1 then
+    if state.is_temp_worktree then
+      -- Return to original directory
+      ya.emit("cd", { target = state.original_cwd })
+      cleanup()
+    else
+      ya.notify({ title = "Git Commit Browser", content = "Already at HEAD", timeout = 2 })
+    end
+    return
+  end
+  
+  -- Navigate to HEAD (index 1)
+  navigate_to_index(1)
+  
+  -- If we were in a temp worktree, cleanup after navigation
+  if state.is_temp_worktree then
+    cleanup()
+  end
+end
+
+-- Get commit info
+local function get_commit_info(commit)
+  local output, err = Command("git")
+    :args({ "log", "-1", "--format=%h %s", commit })
+    :cwd(state.original_repo)
+    :output()
+  
+  if err then
+    return commit:sub(1, 7) .. " (unknown)"
+  end
+  
+  local info = output.stdout:gsub("%s+$", "")
+  return info
+end
+
+-- Publish commit info via DDS
+local function publish_commit_info()
+  local info = get_commit_info(state.current_commit)
+  local hash = info:match("^%S+")
+  local message = info:match("^%S+ (.+)$") or ""
+  
+  -- Truncate message
+  if #message > 30 then
+    message = message:sub(1, 30) .. "..."
+  end
+  
+  ps.pub("git-commit-browser:commit", {
+    hash = hash,
+    message = message,
+    is_temp = state.is_temp_worktree or (state.commit_index ~= 1),
+    index = state.commit_index,
+    total = #state.commit_list
+  })
+end
+
+-- Interactive commit picker using fzf
+local function select_commit()
+  if not init() then return end
+  
+  local commits = {}
+  for i, commit in ipairs(state.commit_list) do
+    local info = get_commit_info(commit)
+    table.insert(commits, info)
+  end
+  
+  -- Use fzf to select
+  local input = table.concat(commits, "\n")
+  local output, err = Command("sh")
+    :args({ "-c", "echo '" .. input:gsub("'", "'\"'\"'") .. "' | fzf --reverse --height=40%" })
+    :stdin(Command.PIPED)
+    :stdout(Command.PIPED)
+    :output()
+  
+  if err or not output.stdout or output.stdout == "" then
+    return
+  end
+  
+  -- Parse selection
+  local selected_hash = output.stdout:match("^%S+")
+  for i, commit in ipairs(state.commit_list) do
+    if commit:sub(1, #selected_hash) == selected_hash then
+      navigate_to_index(i)
+      break
+    end
+  end
+end
+
+-- Cleanup worktrees
+local function cleanup()
+  for commit, path in pairs(state.worktrees) do
+    Command("git")
+      :args({ "worktree", "remove", "--force", path })
+      :cwd(state.original_repo)
+      :output()
+  end
+  state.worktrees = {}
+end
+
+-- Remove orphaned worktrees older than 24h
+local function cleanup_orphaned()
+  local temp_base = get_temp_base()
+  Command("find")
+    :args({ temp_base, "-maxdepth", "1", "-type", "d", "-mtime", "+1", "-exec", "rm", "-rf", "{}", "+" })
+    :output()
+end
+
+-- Main entry point
+return {
+  entry = function(self, args)
+    if not init() then return end
+    
+    local action = args[1] or "next"
+    
+    if action == "next" then
+      navigate("next")
+    elseif action == "prev" then
+      navigate("prev")
+    elseif action == "head" then
+      goto_head()
+    elseif action == "select" then
+      select_commit()
+    elseif action == "cleanup" then
+      cleanup()
+    end
+  end,
+  
+  -- Cleanup on plugin unload
+  __gc = function()
+    if not state.quit_with_q then
+      cleanup()
+    end
+  end
+}

--- a/yazi/plugins/git-commit-browser.yazi/main.lua
+++ b/yazi/plugins/git-commit-browser.yazi/main.lua
@@ -2,366 +2,359 @@
 -- Browse git repository history through temporary worktrees
 
 local state = {
-  original_repo = nil,        -- Absolute path to original .git
-  original_cwd = nil,         -- Absolute path to original working directory
-  repo_hash = nil,            -- 8-char hash of original_repo path
-  current_commit = nil,       -- Current commit hash
-  commit_list = {},           -- Ordered list of commits for navigation
-  commit_index = 1,           -- Current position in commit_list
-  worktrees = {},             -- Map: commit_hash -> worktree_path
-  quit_with_q = false,        -- Flag to skip cleanup
-  is_temp_worktree = false,   -- Whether we started in a temp worktree
-  initialized = false,        -- Whether state has been initialized
+	original_repo = nil, -- Absolute path to original .git
+	original_cwd = nil, -- Absolute path to original working directory
+	repo_hash = nil, -- 8-char hash of original_repo path
+	current_commit = nil, -- Current commit hash
+	commit_list = {}, -- Ordered list of commits for navigation
+	commit_index = 1, -- Current position in commit_list
+	worktrees = {}, -- Map: commit_hash -> worktree_path
+	quit_with_q = false, -- Flag to skip cleanup
+	is_temp_worktree = false, -- Whether we started in a temp worktree
+	initialized = false, -- Whether state has been initialized
 }
-
--- Initialize the plugin state
-local function init()
-  if state.initialized then return true end
-  
-  local cwd = ya.cwd()
-  if not cwd then
-    ya.notify({ title = "Git Commit Browser", content = "Failed to get current directory", timeout = 3 })
-    return false
-  end
-  
-  state.original_cwd = tostring(cwd)
-  
-  -- Check if we're in a temp worktree
-  local temp_pattern = "/tmp/yazi%-git%-browser%-"
-  if state.original_cwd:match(temp_pattern) then
-    state.is_temp_worktree = true
-    -- Extract repo_hash from path
-    state.repo_hash = state.original_cwd:match("/tmp/yazi%-git%-browser%-([^/]+)/")
-    
-    -- Find original repo using git worktree list
-    local output, err = Command("git")
-      :args({ "worktree", "list", "--porcelain" })
-      :cwd(state.original_cwd)
-      :output()
-    
-    if err then
-      ya.notify({ title = "Git Commit Browser", content = "Failed to find original repo: " .. tostring(err), timeout = 3 })
-      return false
-    end
-    
-    -- Parse worktree list to find the main worktree
-    for line in output.stdout:gmatch("[^\r\n]+") do
-      if line:match("^worktree ") then
-        local wt_path = line:sub(10)
-        -- Check if this is the main worktree (not our temp one)
-        if not wt_path:match(temp_pattern) then
-          state.original_repo = wt_path
-          break
-        end
-      end
-    end
-  else
-    -- We're in the original repo
-    state.is_temp_worktree = false
-    state.original_repo = state.original_cwd
-    -- Compute hash of repo path
-    local output, err = Command("sh")
-      :args({ "-c", "echo '" .. state.original_repo .. "' | sha256sum | cut -c1-8" })
-      :output()
-    if err then
-      -- Fallback to simple hash
-      local hash = 0
-      for i = 1, #state.original_repo do
-        hash = (hash * 31 + state.original_repo:byte(i)) % 100000000
-      end
-      state.repo_hash = string.format("%08x", hash)
-    else
-      state.repo_hash = output.stdout:gsub("%s+", "")
-    end
-  end
-  
-  if not state.original_repo then
-    ya.notify({ title = "Git Commit Browser", content = "Not in a git repository", timeout = 3 })
-    return false
-  end
-  
-  -- Load commit list
-  load_commits()
-  
-  state.initialized = true
-  return true
-end
-
--- Load ordered list of commits
-local function load_commits()
-  local output, err = Command("git")
-    :args({ "log", "--format=%H", "--all" })
-    :cwd(state.original_repo)
-    :output()
-  
-  if err then
-    ya.notify({ title = "Git Commit Browser", content = "Failed to load commits: " .. tostring(err), timeout = 3 })
-    return
-  end
-  
-  state.commit_list = {}
-  for hash in output.stdout:gmatch("%x+") do
-    table.insert(state.commit_list, hash)
-  end
-  
-  -- Set current index based on current directory
-  if state.is_temp_worktree then
-    -- Extract commit from path
-    local commit = state.original_cwd:match("/([^/]+)$")
-    for i, c in ipairs(state.commit_list) do
-      if c:sub(1, 7) == commit then
-        state.commit_index = i
-        state.current_commit = c
-        break
-      end
-    end
-  else
-    -- Get HEAD commit
-    local head_output, head_err = Command("git")
-      :args({ "rev-parse", "HEAD" })
-      :cwd(state.original_repo)
-      :output()
-    
-    if not head_err then
-      state.current_commit = head_output.stdout:gsub("%s+", "")
-      for i, c in ipairs(state.commit_list) do
-        if c == state.current_commit then
-          state.commit_index = i
-          break
-        end
-      end
-    end
-  end
-  
-  -- Publish current commit info
-  publish_commit_info()
-end
 
 -- Get temp base directory
 local function get_temp_base()
-  return "/tmp/yazi-git-browser-" .. state.repo_hash
-end
-
--- Create worktree for a commit
-local function create_worktree(commit)
-  if state.worktrees[commit] then
-    return state.worktrees[commit]
-  end
-  
-  local short_hash = commit:sub(1, 7)
-  local temp_base = get_temp_base()
-  local wt_path = temp_base .. "/" .. short_hash
-  
-  -- Create temp base if needed
-  Command("mkdir"):args({ "-p", temp_base }):output()
-  
-  -- Check if worktree already exists
-  local check_cmd = Command("test"):args({ "-d", wt_path }):output()
-  if check_cmd.status and check_cmd.status.code == 0 then
-    state.worktrees[commit] = wt_path
-    return wt_path
-  end
-  
-  -- Create worktree
-  local output, err = Command("git")
-    :args({ "worktree", "add", "--detach", wt_path, commit })
-    :cwd(state.original_repo)
-    :output()
-  
-  if err then
-    ya.notify({ title = "Git Commit Browser", content = "Failed to create worktree: " .. tostring(err), timeout = 3 })
-    return nil
-  end
-  
-  state.worktrees[commit] = wt_path
-  return wt_path
-end
-
--- Navigate to a specific commit by index
-local function navigate_to_index(index)
-  if index < 1 or index > #state.commit_list then
-    return false
-  end
-  
-  state.commit_index = index
-  local commit = state.commit_list[index]
-  state.current_commit = commit
-  
-  local wt_path = create_worktree(commit)
-  if not wt_path then
-    return false
-  end
-  
-  -- Change directory
-  ya.emit("cd", { target = wt_path })
-  
-  -- Publish commit info for status line
-  publish_commit_info()
-  
-  return true
-end
-
--- Navigate direction: "prev" or "next"
-local function navigate(direction)
-  if not init() then return end
-  
-  local new_index
-  if direction == "next" then
-    new_index = state.commit_index + 1
-  elseif direction == "prev" then
-    new_index = state.commit_index - 1
-  else
-    return
-  end
-  
-  if new_index < 1 then
-    ya.notify({ title = "Git Commit Browser", content = "Already at newest commit", timeout = 2 })
-    return
-  end
-  
-  if new_index > #state.commit_list then
-    ya.notify({ title = "Git Commit Browser", content = "Already at oldest commit", timeout = 2 })
-    return
-  end
-  
-  navigate_to_index(new_index)
-end
-
--- Go to HEAD commit
-local function goto_head()
-  if not init() then return end
-  
-  -- Check if at HEAD
-  if state.commit_index == 1 then
-    if state.is_temp_worktree then
-      -- Return to original directory
-      ya.emit("cd", { target = state.original_cwd })
-      cleanup()
-    else
-      ya.notify({ title = "Git Commit Browser", content = "Already at HEAD", timeout = 2 })
-    end
-    return
-  end
-  
-  -- Navigate to HEAD (index 1)
-  navigate_to_index(1)
-  
-  -- If we were in a temp worktree, cleanup after navigation
-  if state.is_temp_worktree then
-    cleanup()
-  end
+	return "/tmp/yazi-git-browser-" .. state.repo_hash
 end
 
 -- Get commit info
 local function get_commit_info(commit)
-  local output, err = Command("git")
-    :args({ "log", "-1", "--format=%h %s", commit })
-    :cwd(state.original_repo)
-    :output()
-  
-  if err then
-    return commit:sub(1, 7) .. " (unknown)"
-  end
-  
-  local info = output.stdout:gsub("%s+$", "")
-  return info
+	local output, err = Command("git"):args({ "log", "-1", "--format=%h %s", commit }):cwd(state.original_repo):output()
+
+	if err then
+		return commit:sub(1, 7) .. " (unknown)"
+	end
+
+	local info = output.stdout:gsub("%s+$", "")
+	return info
 end
 
 -- Publish commit info via DDS
 local function publish_commit_info()
-  local info = get_commit_info(state.current_commit)
-  local hash = info:match("^%S+")
-  local message = info:match("^%S+ (.+)$") or ""
-  
-  -- Truncate message
-  if #message > 30 then
-    message = message:sub(1, 30) .. "..."
-  end
-  
-  ps.pub("git-commit-browser:commit", {
-    hash = hash,
-    message = message,
-    is_temp = state.is_temp_worktree or (state.commit_index ~= 1),
-    index = state.commit_index,
-    total = #state.commit_list
-  })
+	local info = get_commit_info(state.current_commit)
+	local hash = info:match("^%S+")
+	local message = info:match("^%S+ (.+)$") or ""
+
+	-- Truncate message
+	if #message > 30 then
+		message = message:sub(1, 30) .. "..."
+	end
+
+	ps.pub("git-commit-browser:commit", {
+		hash = hash,
+		message = message,
+		is_temp = state.is_temp_worktree or (state.commit_index ~= 1),
+		index = state.commit_index,
+		total = #state.commit_list,
+	})
 end
 
--- Interactive commit picker using fzf
-local function select_commit()
-  if not init() then return end
-  
-  local commits = {}
-  for i, commit in ipairs(state.commit_list) do
-    local info = get_commit_info(commit)
-    table.insert(commits, info)
-  end
-  
-  -- Use fzf to select
-  local input = table.concat(commits, "\n")
-  local output, err = Command("sh")
-    :args({ "-c", "echo '" .. input:gsub("'", "'\"'\"'") .. "' | fzf --reverse --height=40%" })
-    :stdin(Command.PIPED)
-    :stdout(Command.PIPED)
-    :output()
-  
-  if err or not output.stdout or output.stdout == "" then
-    return
-  end
-  
-  -- Parse selection
-  local selected_hash = output.stdout:match("^%S+")
-  for i, commit in ipairs(state.commit_list) do
-    if commit:sub(1, #selected_hash) == selected_hash then
-      navigate_to_index(i)
-      break
-    end
-  end
+-- Load ordered list of commits
+local function load_commits()
+	local output, err = Command("git"):args({ "log", "--format=%H", "--all" }):cwd(state.original_repo):output()
+
+	if err then
+		ya.notify({ title = "Git Commit Browser", content = "Failed to load commits: " .. tostring(err), timeout = 3 })
+		return
+	end
+
+	state.commit_list = {}
+	for hash in output.stdout:gmatch("%x+") do
+		table.insert(state.commit_list, hash)
+	end
+
+	-- Set current index based on current directory
+	if state.is_temp_worktree then
+		-- Extract commit from path
+		local commit = state.original_cwd:match("/([^/]+)$")
+		for i, c in ipairs(state.commit_list) do
+			if c:sub(1, 7) == commit then
+				state.commit_index = i
+				state.current_commit = c
+				break
+			end
+		end
+	else
+		-- Get HEAD commit
+		local head_output, head_err = Command("git"):args({ "rev-parse", "HEAD" }):cwd(state.original_repo):output()
+
+		if not head_err then
+			state.current_commit = head_output.stdout:gsub("%s+", "")
+			for i, c in ipairs(state.commit_list) do
+				if c == state.current_commit then
+					state.commit_index = i
+					break
+				end
+			end
+		end
+	end
+
+	-- Publish current commit info
+	publish_commit_info()
 end
 
 -- Cleanup worktrees
 local function cleanup()
-  for commit, path in pairs(state.worktrees) do
-    Command("git")
-      :args({ "worktree", "remove", "--force", path })
-      :cwd(state.original_repo)
-      :output()
-  end
-  state.worktrees = {}
+	for _, path in pairs(state.worktrees) do
+		Command("git"):args({ "worktree", "remove", "--force", path }):cwd(state.original_repo):output()
+	end
+	state.worktrees = {}
 end
 
--- Remove orphaned worktrees older than 24h
-local function cleanup_orphaned()
-  local temp_base = get_temp_base()
-  Command("find")
-    :args({ temp_base, "-maxdepth", "1", "-type", "d", "-mtime", "+1", "-exec", "rm", "-rf", "{}", "+" })
-    :output()
+-- Initialize the plugin state
+local function init()
+	if state.initialized then
+		return true
+	end
+
+	-- Get current directory using shell since ya.cwd() may not be available
+	local cwd_output, cwd_err = Command("pwd"):stdout(Command.PIPED):output()
+	if cwd_err or not cwd_output.stdout then
+		ya.notify({ title = "Git Commit Browser", content = "Failed to get current directory", timeout = 3 })
+		return false
+	end
+
+	state.original_cwd = cwd_output.stdout:gsub("%s+$", "")
+
+	-- Check if we're in a temp worktree
+	local temp_pattern = "/tmp/yazi%-git%-browser%-"
+	if state.original_cwd:match(temp_pattern) then
+		state.is_temp_worktree = true
+		-- Extract repo_hash from path
+		state.repo_hash = state.original_cwd:match("/tmp/yazi%-git%-browser%-([^/]+)/")
+
+		-- Find original repo using git worktree list
+		local output, err = Command("git"):args({ "worktree", "list", "--porcelain" }):cwd(state.original_cwd):output()
+
+		if err then
+			ya.notify({
+				title = "Git Commit Browser",
+				content = "Failed to find original repo: " .. tostring(err),
+				timeout = 3,
+			})
+			return false
+		end
+
+		-- Parse worktree list to find the main worktree
+		for line in output.stdout:gmatch("[^\r\n]+") do
+			if line:match("^worktree ") then
+				local wt_path = line:sub(10)
+				-- Check if this is the main worktree (not our temp one)
+				if not wt_path:match(temp_pattern) then
+					state.original_repo = wt_path
+					break
+				end
+			end
+		end
+	else
+		-- We're in the original repo
+		state.is_temp_worktree = false
+		state.original_repo = state.original_cwd
+		-- Compute hash of repo path
+		local output, _ =
+			Command("sh"):args({ "-c", "echo '" .. state.original_repo .. "' | sha256sum | cut -c1-8" }):output()
+		if not output then
+			-- Fallback to simple hash
+			local hash = 0
+			for i = 1, #state.original_repo do
+				hash = (hash * 31 + state.original_repo:byte(i)) % 100000000
+			end
+			state.repo_hash = string.format("%08x", hash)
+		else
+			state.repo_hash = output.stdout:gsub("%s+", "")
+		end
+	end
+
+	if not state.original_repo then
+		ya.notify({ title = "Git Commit Browser", content = "Not in a git repository", timeout = 3 })
+		return false
+	end
+
+	-- Load commit list
+	load_commits()
+
+	state.initialized = true
+	return true
+end
+
+-- Create worktree for a commit
+local function create_worktree(commit)
+	if state.worktrees[commit] then
+		return state.worktrees[commit]
+	end
+
+	local short_hash = commit:sub(1, 7)
+	local temp_base = get_temp_base()
+	local wt_path = temp_base .. "/" .. short_hash
+
+	-- Create temp base if needed
+	Command("mkdir"):args({ "-p", temp_base }):output()
+
+	-- Check if worktree already exists
+	local check_cmd = Command("test"):args({ "-d", wt_path }):output()
+	if check_cmd.status and check_cmd.status.code == 0 then
+		state.worktrees[commit] = wt_path
+		return wt_path
+	end
+
+	-- Create worktree
+	local _, err =
+		Command("git"):args({ "worktree", "add", "--detach", wt_path, commit }):cwd(state.original_repo):output()
+
+	if err then
+		ya.notify({
+			title = "Git Commit Browser",
+			content = "Failed to create worktree: " .. tostring(err),
+			timeout = 3,
+		})
+		return nil
+	end
+
+	state.worktrees[commit] = wt_path
+	return wt_path
+end
+
+-- Navigate to a specific commit by index
+local function navigate_to_index(index)
+	if index < 1 or index > #state.commit_list then
+		return false
+	end
+
+	state.commit_index = index
+	local commit = state.commit_list[index]
+	state.current_commit = commit
+
+	local wt_path = create_worktree(commit)
+	if not wt_path then
+		return false
+	end
+
+	-- Change directory
+	ya.emit("cd", { target = wt_path })
+
+	-- Publish commit info for status line
+	publish_commit_info()
+
+	return true
+end
+
+-- Navigate direction: "prev" or "next"
+local function navigate(direction)
+	if not init() then
+		return
+	end
+
+	local new_index
+	if direction == "next" then
+		new_index = state.commit_index + 1
+	elseif direction == "prev" then
+		new_index = state.commit_index - 1
+	else
+		return
+	end
+
+	if new_index < 1 then
+		ya.notify({ title = "Git Commit Browser", content = "Already at newest commit", timeout = 2 })
+		return
+	end
+
+	if new_index > #state.commit_list then
+		ya.notify({ title = "Git Commit Browser", content = "Already at oldest commit", timeout = 2 })
+		return
+	end
+
+	navigate_to_index(new_index)
+end
+
+-- Go to HEAD commit
+local function goto_head()
+	if not init() then
+		return
+	end
+
+	-- Check if at HEAD
+	if state.commit_index == 1 then
+		if state.is_temp_worktree then
+			-- Return to original directory
+			ya.emit("cd", { target = state.original_cwd })
+			cleanup()
+		else
+			ya.notify({ title = "Git Commit Browser", content = "Already at HEAD", timeout = 2 })
+		end
+		return
+	end
+
+	-- Navigate to HEAD (index 1)
+	navigate_to_index(1)
+
+	-- If we were in a temp worktree, cleanup after navigation
+	if state.is_temp_worktree then
+		cleanup()
+	end
+end
+
+-- Interactive commit picker using fzf
+local function select_commit()
+	if not init() then
+		return
+	end
+
+	local commits = {}
+	for _, commit in ipairs(state.commit_list) do
+		local info = get_commit_info(commit)
+		table.insert(commits, info)
+	end
+
+	-- Use fzf to select
+	local input = table.concat(commits, "\n")
+	local output, err = Command("sh")
+		:args({ "-c", "echo '" .. input:gsub("'", "'\"'\"'") .. "' | fzf --reverse --height=40%" })
+		:stdin(Command.PIPED)
+		:stdout(Command.PIPED)
+		:output()
+
+	if err or not output.stdout or output.stdout == "" then
+		return
+	end
+
+	-- Parse selection
+	local selected_hash = output.stdout:match("^%S+")
+	for i, commit in ipairs(state.commit_list) do
+		if commit:sub(1, #selected_hash) == selected_hash then
+			navigate_to_index(i)
+			break
+		end
+	end
 end
 
 -- Main entry point
 return {
-  entry = function(self, args)
-    if not init() then return end
-    
-    local action = args[1] or "next"
-    
-    if action == "next" then
-      navigate("next")
-    elseif action == "prev" then
-      navigate("prev")
-    elseif action == "head" then
-      goto_head()
-    elseif action == "select" then
-      select_commit()
-    elseif action == "cleanup" then
-      cleanup()
-    end
-  end,
-  
-  -- Cleanup on plugin unload
-  __gc = function()
-    if not state.quit_with_q then
-      cleanup()
-    end
-  end
+	entry = function(_, args)
+		if not init() then
+			return
+		end
+
+		local action = args[1] or "next"
+
+		if action == "next" then
+			navigate("next")
+		elseif action == "prev" then
+			navigate("prev")
+		elseif action == "head" then
+			goto_head()
+		elseif action == "select" then
+			select_commit()
+		elseif action == "cleanup" then
+			cleanup()
+		end
+	end,
+
+	-- Cleanup on plugin unload
+	__gc = function()
+		if not state.quit_with_q then
+			cleanup()
+		end
+	end,
 }


### PR DESCRIPTION
## Summary

A Yazi plugin that enables browsing git repository history through temporary worktrees, with seamless navigation between commits and automatic cleanup.

## Features

- **Navigate commits**: Use `]` to go to older commits, `[` to go to newer commits
- **Interactive picker**: Press `g]` to open fzf and select any commit
- **Return to HEAD**: Press `g[` to return to the original working directory
- **Status line integration**: Publishes commit info via DDS for custom status line display
- **Automatic cleanup**: Worktrees are cleaned up when returning to HEAD or quitting Yazi

## Implementation

### Files Added
- `yazi/plugins/git-commit-browser.yazi/main.lua` - Core plugin logic (~250 lines)
- `yazi/plugins/git-commit-browser.yazi/README.md` - Usage documentation
- `yazi/plugins/git-commit-browser.yazi/LICENSE` - MIT License

### Files Modified
- `nix/modules/yazi.nix` - Added plugin derivation and keybindings

## Keybindings

| Key | Action | Description |
|-----|--------|-------------|
| `]` | next | Go to older commit |
| `[` | prev | Go to newer commit |
| `g[` | head | Return to HEAD/original directory |
| `g]` | select | Interactive commit picker (fzf) |

## Testing

- [ ] Test navigation in original repo
- [ ] Test resuming from temp worktree
- [ ] Test cleanup on `g[` at HEAD
- [ ] Test interactive picker
- [ ] Test status line integration

## Future Improvements

- Add support for viewing diffs between commits
- Add branch creation from historical commits
- Add cleanup of orphaned worktrees (24h+ old)