### PR TITLE
Make CI checks conditional

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,7 +12,80 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      workflow: ${{ steps.workflow.outputs.any_changed }}
+      gha: ${{ steps.gha.outputs.any_changed }}
+      lua: ${{ steps.lua.outputs.any_changed }}
+      nix: ${{ steps.nix.outputs.any_changed }}
+      rust: ${{ steps.rust.outputs.any_changed }}
+      flake: ${{ steps.flake.outputs.any_changed }}
+
+    steps:
+      - name: Checkout repository
+        timeout-minutes: 5
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Detect workflow changes
+        timeout-minutes: 5
+        id: workflow
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        with:
+          files: |
+            .github/workflows/check.yaml
+
+      - name: Detect GitHub Actions changes
+        timeout-minutes: 5
+        id: gha
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        with:
+          files: |
+            .github/**
+
+      - name: Detect Lua changes
+        timeout-minutes: 5
+        id: lua
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        with:
+          files: |
+            **/*.lua
+            .luacheckrc
+            .stylua.toml
+            stylua.toml
+
+      - name: Detect Nix changes
+        timeout-minutes: 5
+        id: nix
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        with:
+          files: |
+            **/*.nix
+            flake.lock
+
+      - name: Detect Rust changes
+        timeout-minutes: 5
+        id: rust
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        with:
+          files: |
+            rs/**
+
+      - name: Detect flake input changes
+        timeout-minutes: 5
+        id: flake
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        with:
+          files: |
+            **/*.nix
+            flake.lock
+            rs/**
+
   check-gha:
+    needs: changes
+    if: ${{ needs.changes.outputs.gha == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +113,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # needed for zizmor
 
   check-lua:
+    needs: changes
+    if: ${{ needs.changes.outputs.lua == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -65,6 +140,8 @@ jobs:
           nix develop .#ci-lua -c just check-lua
 
   check-nix:
+    needs: changes
+    if: ${{ needs.changes.outputs.nix == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -90,6 +167,8 @@ jobs:
           nix develop .#ci-nix -c just check-nix
 
   flake-check:
+    needs: changes
+    if: ${{ needs.changes.outputs.flake == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -115,6 +194,8 @@ jobs:
           nix develop .#ci-nix -c just test-nix
 
   check-rs:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -155,6 +236,8 @@ jobs:
           nix develop .#ci-rs -c just check-rs
 
   test-rs:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -195,8 +278,10 @@ jobs:
           nix develop .#ci-rs -c just test-rs
 
   check:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs:
+      - changes
       - check-gha
       - check-lua
       - check-nix
@@ -205,6 +290,10 @@ jobs:
       - test-rs
 
     steps:
+      - name: Fail if any job failed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+
       - name: Check workflow success
         run: |
           echo "All checks passed."


### PR DESCRIPTION
## Summary
- add a change-detection job to scope check workflows to relevant file changes
- gate each CI check on the paths it covers or workflow edits
- keep the final check job reporting failures even when other jobs are skipped

## Testing
- `just nice`
- `just check`