### PR TITLE
feat(nvim): add fff.nvim picker

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,6 +50,42 @@
         "type": "github"
       }
     },
+    "crane": {
+      "locked": {
+        "lastModified": 1767744144,
+        "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2fb033290bf6b23f226d4c8b32f7f7a16b043d7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fff-nvim": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1771272771,
+        "narHash": "sha256-XT3XTTaXiT1A20BZoZDBAbGIiaer3s7vrWQz7aDeoWE=",
+        "owner": "dmtrKovalenko",
+        "repo": "fff.nvim",
+        "rev": "6a3e481175e63cc09799a06d51b112e75e80df6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dmtrKovalenko",
+        "repo": "fff.nvim",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -146,7 +182,25 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -309,7 +363,7 @@
           "nixpkgs"
         ],
         "pre-commit-hooks": "pre-commit-hooks",
-        "systems": "systems",
+        "systems": "systems_2",
         "xdph": "xdph"
       },
       "locked": {
@@ -613,7 +667,7 @@
       "inputs": {
         "flake-parts": "flake-parts_2",
         "neovim-src": "neovim-src",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1769385907,
@@ -764,11 +818,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769330179,
-        "narHash": "sha256-yxgb4AmkVHY5OOBrC79Vv6EVd4QZEotqv+6jcvA212M=",
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48698d12cc10555a4f3e3222d9c669b884a49dfe",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
         "type": "github"
       },
       "original": {
@@ -780,7 +834,7 @@
     },
     "nixpkgs-firefox-darwin": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1769390283,
@@ -798,6 +852,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1769330179,
+        "narHash": "sha256-yxgb4AmkVHY5OOBrC79Vv6EVd4QZEotqv+6jcvA212M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "48698d12cc10555a4f3e3222d9c669b884a49dfe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1769170682,
         "narHash": "sha256-oMmN1lVQU0F0W2k6OI3bgdzp2YOHWYUAw79qzDSjenU=",
         "owner": "nixos",
@@ -812,7 +882,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1746683680,
         "narHash": "sha256-+5zk+UbG0+GQlKt+gIKm+OhlYvHmkAHFXvf7hl1HDeM=",
@@ -828,7 +898,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1768875095,
         "narHash": "sha256-dYP3DjiL7oIiiq3H65tGIXXIT1Waiadmv93JS0sS+8A=",
@@ -844,7 +914,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1768875095,
         "narHash": "sha256-dYP3DjiL7oIiiq3H65tGIXXIT1Waiadmv93JS0sS+8A=",
@@ -866,8 +936,8 @@
         "flake-parts": "flake-parts_3",
         "mnw": "mnw",
         "ndg": "ndg",
-        "nixpkgs": "nixpkgs_4",
-        "systems": "systems_2"
+        "nixpkgs": "nixpkgs_5",
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1769403795,
@@ -924,6 +994,7 @@
     },
     "root": {
       "inputs": {
+        "fff-nvim": "fff-nvim",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
         "homebrew-cask": "homebrew-cask",
@@ -935,7 +1006,7 @@
         "nix-homebrew": "nix-homebrew",
         "nix-index-database": "nix-index-database",
         "nix-rosetta-builder": "nix-rosetta-builder",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-firefox-darwin": "nixpkgs-firefox-darwin",
         "nvf": "nvf",
         "path-from-root-yazi": "path-from-root-yazi",
@@ -945,6 +1016,27 @@
       }
     },
     "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "fff-nvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770865833,
+        "narHash": "sha256-oiARqnlvaW6pVGheVi4ye6voqCwhg5hCcGish2ZvQzI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c8cfbe26238638e2f3a2c0ae7e8d240f5e4ded85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "yazi",
@@ -1003,6 +1095,21 @@
     },
     "systems": {
       "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
@@ -1016,7 +1123,7 @@
         "type": "github"
       }
     },
-    "systems_2": {
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1031,7 +1138,7 @@
         "type": "github"
       }
     },
-    "systems_3": {
+    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1089,9 +1196,9 @@
     },
     "yazi": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_5",
-        "rust-overlay": "rust-overlay"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_6",
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
         "lastModified": 1769419437,

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
     sops-nix.url = "github:Mic92/sops-nix";
     yazi.url = "github:sxyazi/yazi";
     neovim-nightly-overlay.url = "github:nix-community/neovim-nightly-overlay";
+    fff-nvim.url = "github:dmtrKovalenko/fff.nvim";
     nix-rosetta-builder = {
       url = "github:cpick/nix-rosetta-builder";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/modules/neovim.nix
+++ b/nix/modules/neovim.nix
@@ -20,6 +20,7 @@ in
           vimAlias = true;
           initLua = "require(\"rafiq\")";
           plugins = with pkgs.vimPlugins; [
+            inputs.fff-nvim.packages.${pkgs.stdenv.hostPlatform.system}.fff-nvim
             fidget-nvim
             mini-nvim
             nvim-lspconfig

--- a/nvim/rafiq.lua
+++ b/nvim/rafiq.lua
@@ -4,6 +4,7 @@
 
 require("mini.pick").setup()
 require("fidget").setup()
+require("fff").setup()
 local yazi = require("yazi")
 vim.g.loaded_netrwPlugin = 1
 vim.api.nvim_create_autocmd("UIEnter", {
@@ -41,8 +42,13 @@ vim.keymap.set("n", "n", "nzz", { desc = "Center screen on next search" })
 vim.keymap.set("n", "N", "Nzz", { desc = "Center screen on prev search" })
 
 --- ACTIVE
-vim.keymap.set("n", "<leader>ff", ":Pick files<CR>", { desc = "Picker: Files" })
-vim.keymap.set("n", "<leader>fg", ":Pick grep_live<CR>", { desc = "Picker: Live Grep" })
+vim.keymap.set("n", "<leader>ff", function()
+	require("fff").find_files()
+end, { desc = "FFF: Files" })
+
+vim.keymap.set("n", "<leader>fg", function()
+	require("fff").live_grep()
+end, { desc = "FFF: Live Grep" })
 
 vim.keymap.set("n", "<leader>la", function()
 	vim.lsp.buf.code_action()

--- a/sessions/2026-02-17-fff-nvim.md
+++ b/sessions/2026-02-17-fff-nvim.md
@@ -1,0 +1,17 @@
+## Work Summary
+- Added the fff.nvim flake input and wired the packaged plugin into the Neovim home-manager module.
+- Swapped the <leader>ff and <leader>fg mappings to use fff.nvim file finding and live grep.
+- Updated the flake lockfile for the new input.
+
+## Decisions
+- Used the upstream flake's `packages.<system>.fff-nvim` output so the bundled Rust backend is built via Nix.
+- Kept default fff.nvim configuration (only `setup()`), since defaults are already sensible and match the requested keymap swap.
+
+## Notes
+- fff.nvim expects Neovim 0.10+ and uses a Rust backend; the flake output provides the compiled dynamic library.
+
+## Learnings
+- fff.nvim ships a Nix flake with a `fff-nvim` Vim plugin package that already handles copying the Rust library into `target/release`.
+
+## Bugs Encountered
+- None.


### PR DESCRIPTION
## Summary
- add fff.nvim as a flake input and Neovim plugin package
- switch <leader>ff/<leader>fg to use fff.nvim file and live grep pickers
- document the change in a new session note