### PR TITLE
feat(nix): add Linux Ghostty macOS-style keybindings

### DIFF
--- a/docs/ghostty.md
+++ b/docs/ghostty.md
@@ -1,0 +1,16 @@
+# ghostty
+
+Linux-only Home Manager keybinds are defined in `nix/modules/ghostty.nix` under `programs.ghostty.settings`.
+
+macOS-like bindings enabled on Linux:
+
+- `cmd+t` new tab, `cmd+w` close surface
+- `cmd+shift+[` previous tab, `cmd+shift+]` next tab
+- `cmd+d` split right, `cmd+shift+d` split down
+- `cmd+alt+arrow` move focus across splits
+- `cmd+c` copy, `cmd+v` paste
+- `alt+left/right` word movement
+- `cmd+left/right` line start/end
+- `alt+backspace` delete previous word
+- `cmd+backspace` delete to line start
+- `cmd+delete` delete next word

--- a/nix/modules/ghostty.nix
+++ b/nix/modules/ghostty.nix
@@ -4,11 +4,34 @@
       homebrew.casks = [ "ghostty" ];
     };
     modules.homeManager.rafiq =
-      { pkgs, ... }:
+      { lib, pkgs, ... }:
       {
         programs.ghostty = {
           enable = true;
           package = if pkgs.stdenv.isDarwin then null else pkgs.ghostty; # ghostty broken on darwin
+          settings = lib.mkIf pkgs.stdenv.isLinux {
+            keybind = [
+              "cmd+t=new_tab"
+              "cmd+w=close_surface"
+              "cmd+shift+[=previous_tab"
+              "cmd+shift+]=next_tab"
+              "cmd+d=new_split:right"
+              "cmd+shift+d=new_split:down"
+              "cmd+alt+left=goto_split:left"
+              "cmd+alt+right=goto_split:right"
+              "cmd+alt+up=goto_split:up"
+              "cmd+alt+down=goto_split:down"
+              "cmd+c=copy_to_clipboard"
+              "cmd+v=paste_from_clipboard"
+              "alt+left=esc:b"
+              "alt+right=esc:f"
+              "alt+backspace=text:\\x17"
+              "cmd+left=text:\\x01"
+              "cmd+right=text:\\x05"
+              "cmd+backspace=text:\\x15"
+              "cmd+delete=esc:d"
+            ];
+          };
         };
       };
   };

--- a/sessions/2026-02-20-ghostty-linux-macos-keybinds.md
+++ b/sessions/2026-02-20-ghostty-linux-macos-keybinds.md
@@ -1,0 +1,28 @@
+# Ghostty Linux macOS-like Keybinds
+
+Date: 2026-02-20
+Task: Add Linux-only Home Manager Ghostty keybindings that mimic macOS defaults for tab/split management, clipboard actions, and text navigation/editing.
+
+## Work Breakdown
+
+1. Reviewed project Nix conventions in `.agents/skills/nix/SKILL.md`.
+2. Located existing Ghostty module in `nix/modules/ghostty.nix`.
+3. Retrieved Ghostty keybinding docs and action reference from ghostty.org to verify syntax and action names.
+4. Added Linux-gated keybindings under `programs.ghostty.settings` using `lib.mkIf pkgs.stdenv.isLinux`.
+
+## Decisions and Reasoning
+
+- Kept configuration in the existing Ghostty Home Manager module to preserve one-file responsibility.
+- Scoped keybindings to Linux only so Darwin behavior remains native/unmodified.
+- Used `cmd` modifier in bindings to mirror macOS muscle memory on Linux (mapped to Super).
+- Included tab traversal mappings (`cmd+shift+[`, `cmd+shift+]`) alongside tab creation/close.
+- Used terminal-safe escape/control sequences for word and line navigation/editing:
+  - `alt+left/right` -> `esc:b` / `esc:f`
+  - `cmd+left/right` -> `Ctrl-A` / `Ctrl-E`
+  - `alt+backspace`, `cmd+backspace`, `cmd+delete` for common shell text edits.
+
+## Notes
+
+- Existing package gating (`package = if pkgs.stdenv.isDarwin then null else pkgs.ghostty`) remains unchanged.
+- Added concise documentation at `docs/ghostty.md`.
+- No formatting/lint/test command run in this step.


### PR DESCRIPTION
## Summary
- add Linux-only Ghostty Home Manager keybindings that mirror macOS-style tab, split, clipboard, and text-edit shortcuts
- keep Darwin behavior unchanged by gating keybind settings to Linux in the Ghostty module
- add a minimal `docs/ghostty.md` reference for the configured keybindings