### PR TITLE
feat: add workspace launcher and no-prefix tmux workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ You may add to this file anything that you think you should remember in the futu
 - Refer to `.agents/skills/session-management/SKILL.md` for instructions on managing and processing session notes.
 - Refer to `.agents/skills/opencode-docs-index/SKILL.md` for comprehensive documentation on Opencode docs.
 - For tmux orchestration patterns for CLI-agent E2E runs, use `.agents/skills/tmux-e2e-cli-agent/SKILL.md`.
+- Always keep a process note open as an engineering notebook for every task.
+- Deploy workspaces as a pair: process note + app context.
 
 ## Instructions from Agent
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ these are the tools i currently use
 - `just check` runs the same check run in CI for formatting, linting, and testing
 - `just rb` rebuilds the local Darwin system configuration after running `nice`, then `check`.
     *- planned: allow specifying remote to rebuild, add support for not-Darwins*
+- `workspace <task-name> [app-dir]` starts a tmux workspace with process note + app shell.
 
 ## acknowledgements
 

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -1,0 +1,17 @@
+# tmux
+
+## keybinds (no prefix)
+
+- `Ctrl+w`: close current pane
+- `Ctrl+d`: split pane to the right
+- `Ctrl+Shift+d`: split pane downward
+- `Ctrl+h/j/k/l`: move focus left/down/up/right
+- `Ctrl+Shift+h/j/k/l`: resize pane left/down/up/right
+- `Ctrl+Tab`: next tmux window
+- `Ctrl+Shift+Tab`: previous tmux window
+
+## notes
+
+- Keybinds are configured in `nix/modules/tmux.nix` via Home Manager `programs.tmux.extraConfig`.
+- Split operations keep the same working directory as the active pane.
+- `Ctrl+Shift+...` keybinds require terminal support for extended key reporting.

--- a/nix/modules/aliases.nix
+++ b/nix/modules/aliases.nix
@@ -9,12 +9,14 @@ in
       {
         home.packages = [
           (pkgs.writeShellScriptBin "process" (lib.fileContents (cfg.paths.root + "/scripts/process.sh")))
+          (pkgs.writeShellScriptBin "workspace" (lib.fileContents (cfg.paths.root + "/scripts/workspace.sh")))
         ];
 
         home.shellAliases = {
           v = "$EDITOR";
           e = "fish -c 'set -e var; set var (sk); test -n \"$var\"; and $EDITOR $var'";
           pedia = "process \"$HOME/1_repos/pedia\"";
+          ws = "workspace";
           day = "v ~/0_library/notes/daily/$(date +%F).md";
           month = "v ~/0_library/notes/monthly/$(date +%Y-%m).md";
         };

--- a/nix/modules/tmux.nix
+++ b/nix/modules/tmux.nix
@@ -1,0 +1,27 @@
+{
+  config.flake.modules.homeManager.rafiq = {
+    programs.tmux = {
+      enable = true;
+      extraConfig = ''
+        set -g extended-keys on
+
+        bind-key -n C-w kill-pane
+        bind-key -n C-d split-window -h -c "#{pane_current_path}"
+        bind-key -n C-S-d split-window -v -c "#{pane_current_path}"
+
+        bind-key -n C-h select-pane -L
+        bind-key -n C-j select-pane -D
+        bind-key -n C-k select-pane -U
+        bind-key -n C-l select-pane -R
+
+        bind-key -n C-S-h resize-pane -L 5
+        bind-key -n C-S-j resize-pane -D 5
+        bind-key -n C-S-k resize-pane -U 5
+        bind-key -n C-S-l resize-pane -R 5
+
+        bind-key -n C-Tab next-window
+        bind-key -n C-S-Tab previous-window
+      '';
+    };
+  };
+}

--- a/scripts/workspace.sh
+++ b/scripts/workspace.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  printf 'Usage: workspace <task-name> [app-dir]\n' >&2
+  exit 1
+fi
+
+task_name="$1"
+app_dir="${2:-$PWD}"
+note_dir="${WORKSPACE_NOTE_DIR:-$HOME/0_library/notes/process}"
+right_pane_percent="${WORKSPACE_RIGHT_PANE_PERCENT:-70}"
+
+if ! command -v tmux >/dev/null 2>&1; then
+  printf 'tmux is required but was not found in PATH\n' >&2
+  exit 1
+fi
+
+if [ ! -d "$app_dir" ]; then
+  printf 'App directory does not exist: %s\n' "$app_dir" >&2
+  exit 1
+fi
+
+if ! [[ "$right_pane_percent" =~ ^[0-9]+$ ]] || [ "$right_pane_percent" -lt 1 ] || [ "$right_pane_percent" -gt 99 ]; then
+  printf 'WORKSPACE_RIGHT_PANE_PERCENT must be an integer between 1 and 99\n' >&2
+  exit 1
+fi
+
+slug="$(printf '%s' "$task_name" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
+slug="${slug#-}"
+slug="${slug%-}"
+
+if [ -z "$slug" ]; then
+  printf 'Task name must contain at least one alphanumeric character\n' >&2
+  exit 1
+fi
+
+mkdir -p "$note_dir"
+
+note_path="$note_dir/$(date +%F)-$slug.md"
+if [ ! -e "$note_path" ]; then
+  cat >"$note_path" <<EOF
+# $task_name
+
+## Goal
+
+## Context
+
+## Steps
+
+## Notes
+
+## Verification
+EOF
+fi
+
+session_name="ws-$slug"
+
+if ! tmux has-session -t "$session_name" 2>/dev/null; then
+  tmux new-session -d -s "$session_name" -c "$app_dir"
+  tmux send-keys -t "$session_name:0.0" "nvim \"$note_path\"" C-m
+  tmux split-window -h -p "$right_pane_percent" -t "$session_name:0.0" -c "$app_dir"
+  tmux select-pane -t "$session_name:0.1"
+fi
+
+if [ -n "${TMUX:-}" ]; then
+  exec tmux switch-client -t "$session_name"
+fi
+
+exec tmux attach-session -t "$session_name"

--- a/sessions/2026-02-20-tmux-keybinds.md
+++ b/sessions/2026-02-20-tmux-keybinds.md
@@ -1,0 +1,31 @@
+# Task
+
+Add tmux root keybindings (no prefix) for pane/window management.
+
+## Requirements
+
+- `Ctrl+w`: close pane
+- `Ctrl+d`: split right
+- `Ctrl+Shift+d`: split down
+- `Ctrl+h/j/k/l`: move between panes
+- `Ctrl+Shift+h/j/k/l`: resize pane left/down/up/right
+- `Ctrl+Tab`: move between windows
+- `Ctrl+Shift+Tab`: reverse window cycling
+
+## Work Performed
+
+1. Searched repo for existing tmux config and found none.
+2. Added `nix/modules/tmux.nix` with Home Manager `programs.tmux.enable = true`.
+3. Added root (`-n`) keybindings implementing requested controls.
+4. Enabled `extended-keys` in tmux config to improve support for `Ctrl+Shift+<key>` combinations.
+5. Added reverse tab cycling with `Ctrl+Shift+Tab` mapped to previous window.
+6. Documented tmux keybinds in `docs/tmux.md`.
+
+## Notes
+
+- Split bindings preserve working directory using `-c "#{pane_current_path}"`.
+- `Ctrl+Shift+...` handling depends on terminal support for extended key reporting.
+
+## Verification
+
+- Ran `just check` successfully.

--- a/sessions/2026-02-20-workspace-layout.md
+++ b/sessions/2026-02-20-workspace-layout.md
@@ -1,0 +1,41 @@
+# Task
+
+Implement a tmux workspace launcher that enforces a process-note-plus-app workflow and supports a two-pane layout.
+
+## Work Performed
+
+1. Reviewed existing note tooling and conventions:
+   - `scripts/process.sh`
+   - `nvim/rafiq.lua`
+   - `nix/modules/aliases.nix`
+   - `AGENTS.md`
+2. Added user memory requirements to `AGENTS.md`:
+   - Always keep a process note open as an engineering notebook.
+   - Deploy workspaces as process note + app context.
+3. Added `scripts/workspace.sh`:
+   - Creates/opens a dated process note: `YYYY-MM-DD-<task-slug>.md`
+   - Creates/reuses tmux session: `ws-<task-slug>`
+   - Left pane: opens note in Neovim
+   - Right pane: shell in app directory
+   - Layout default: right pane 70% (left pane 30%)
+   - Supports override via `WORKSPACE_RIGHT_PANE_PERCENT`
+4. Wired command into Home Manager package aliases:
+   - Added `workspace` binary package from `scripts/workspace.sh`
+   - Added alias `ws="workspace"`
+5. Documented command in `README.md` day-to-day section.
+
+## Decisions
+
+- Use tmux split percentage from right pane (`-p 70`) to satisfy requested 30/70 layout.
+- Use one session per task slug to make re-attachment deterministic.
+- Keep note path under existing process notes directory for continuity with current workflow.
+
+## Learning
+
+- A small launcher script can enforce the process-note-first habit without changing Neovim keymaps.
+- tmux session reuse makes iterative task sessions easier and avoids duplicate panes.
+
+## Verification
+
+- Ran `just check` successfully.
+- Noted a Nix flake gotcha during first run: untracked files are not visible via flake source paths. The first check failed because `scripts/workspace.sh` was untracked; after staging the file, checks passed.


### PR DESCRIPTION
## Summary
- add a `workspace` launcher script that creates/opens a dated process note and starts a tmux session with a 30/70 note+app layout
- wire the launcher into Home Manager aliases (`workspace` and `ws`) and document usage in `README.md`
- add no-prefix tmux keybindings for pane management and window cycling (including reverse cycling with `Ctrl+Shift+Tab`), with docs in `docs/tmux.md`
- record implementation details and verification notes in session files for this task

## Why
This standardizes a note-first engineering workflow and reduces tmux friction by matching requested direct keybindings without a leader key.