### PR TITLE
feat(nix): add shared Neovim server/client editor flow

### DIFF
--- a/nix/modules/neovim.nix
+++ b/nix/modules/neovim.nix
@@ -1,6 +1,7 @@
 {
   inputs,
   config,
+  lib,
   ...
 }:
 let
@@ -9,20 +10,49 @@ in
 {
   config.flake = {
     modules.homeManager.rafiq =
-      { pkgs, ... }:
+      {
+        pkgs,
+        config,
+        ...
+      }:
       let
         epub-nvim = pkgs.vimUtils.buildVimPlugin {
           pname = "epub.nvim";
           version = "main";
           src = inputs.epub-nvim;
         };
+        nvim-server-address = "$XDG_RUNTIME_DIR/nvim/server.pipe";
+        nvim-client = pkgs.writeShellScriptBin "nvim-client" ''
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          server="''${NVIM_SERVER:-${nvim-server-address}}"
+          nvim_bin="${lib.getExe config.programs.neovim.finalPackage}"
+
+          if [[ ! -S "$server" ]]; then
+            if command -v systemctl >/dev/null 2>&1; then
+              systemctl --user start nvim-server.service >/dev/null 2>&1 || true
+            fi
+
+            for _ in {1..40}; do
+              [[ -S "$server" ]] && break
+              sleep 0.05
+            done
+          fi
+
+          if [[ -S "$server" ]]; then
+            exec "$nvim_bin" --server "$server" --remote-ui "$@"
+          fi
+
+          exec "$nvim_bin" "$@"
+        '';
       in
       {
         xdg.configFile."nvim/lua".source = root + /nvim;
         programs.neovim = {
           enable = true;
           package = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.default;
-          defaultEditor = true;
+          defaultEditor = false;
           viAlias = true;
           vimAlias = true;
           initLua = "require(\"rafiq\")";
@@ -49,6 +79,30 @@ in
             stylua
             unzip
           ];
+        };
+
+        home.packages = [ nvim-client ];
+
+        home.sessionVariables = {
+          EDITOR = "nvim-client";
+          VISUAL = "nvim-client";
+        };
+
+        systemd.user.services.nvim-server = lib.mkIf pkgs.stdenv.isLinux {
+          Unit = {
+            Description = "Neovim headless server";
+            After = [ "graphical-session-pre.target" ];
+          };
+          Service = {
+            Type = "simple";
+            ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p $XDG_RUNTIME_DIR/nvim";
+            ExecStart = "${lib.getExe config.programs.neovim.finalPackage} --headless --listen ${nvim-server-address}";
+            Restart = "always";
+            RestartSec = "1s";
+          };
+          Install = {
+            WantedBy = [ "default.target" ];
+          };
         };
       };
   };

--- a/sessions/2026-02-20-nvim-server-client.md
+++ b/sessions/2026-02-20-nvim-server-client.md
@@ -1,0 +1,30 @@
+# 2026-02-20 - Neovim server + client editor flow
+
+## Goal
+
+Configure Home Manager so Neovim runs as a background server and `$EDITOR` opens a client UI attached to that server.
+
+## Changes made
+
+- Updated `nix/modules/neovim.nix` to add a Linux user service `systemd.user.services.nvim-server`.
+- Service runs Neovim headless with a fixed listen address: `$XDG_RUNTIME_DIR/nvim/server.pipe`.
+- Added `ExecStartPre` to create runtime socket directory.
+- Added a wrapper command `nvim-client` via `writeShellScriptBin`.
+  - Uses `NVIM_SERVER` (defaulting to `$XDG_RUNTIME_DIR/nvim/server.pipe`).
+  - Attempts to start `nvim-server.service` if socket is missing.
+  - Waits briefly for socket creation.
+  - Opens remote UI with `--server ... --remote-ui`, falls back to normal `nvim` if server is unavailable.
+- Disabled `programs.neovim.defaultEditor` and set:
+  - `home.sessionVariables.EDITOR = "nvim-client"`
+  - `home.sessionVariables.VISUAL = "nvim-client"`
+- Added `nvim-client` to `home.packages`.
+
+## Decisions
+
+- Kept Neovim package/config source as `programs.neovim` and referenced `config.programs.neovim.finalPackage` in both service and wrapper so server/client always use the same configured Neovim binary.
+- Kept service Linux-only with `lib.mkIf pkgs.stdenv.isLinux` because this uses `systemd.user.services`.
+
+## Notes / gotchas
+
+- `--remote-ui` creates a fully interactive client UI attached to the server process, so registers and state are shared.
+- Fallback to plain `nvim` in wrapper prevents hard failure if service/socket is unavailable.


### PR DESCRIPTION
## Summary
- run Neovim as a Home Manager `systemd --user` headless server on a fixed runtime socket
- add an `nvim-client` wrapper that starts/attaches to the server via `--remote-ui` and falls back to local nvim
- set `EDITOR`/`VISUAL` to `nvim-client` and capture implementation notes in a new session file