### PR TITLE
feat(nix): add yt-meta package and home-manager wiring

### DIFF
--- a/nix/modules/aliases.nix
+++ b/nix/modules/aliases.nix
@@ -9,6 +9,7 @@ in
       {
         home.packages = [
           (pkgs.writeShellScriptBin "process" (lib.fileContents (cfg.paths.root + "/scripts/process.sh")))
+          cfg.packages.${pkgs.stdenv.hostPlatform.system}.yt-meta
         ];
 
         home.shellAliases = {

--- a/nix/outputs/packages.nix
+++ b/nix/outputs/packages.nix
@@ -3,28 +3,65 @@
   perSystem =
     { pkgs, self', ... }:
     {
-      packages.site-bin = pkgs.rustPlatform.buildRustPackage {
-        name = "site";
-        src = config.flake.paths.root + /rs;
-        cargoLock.lockFile = config.flake.paths.root + /rs/Cargo.lock;
-      };
-      packages.site-image = pkgs.dockerTools.buildLayeredImage {
-        name = "site";
-        tag = "latest";
-        contents = [
-          self'.packages.site-bin
-          pkgs.dockerTools.binSh
-        ];
-        config = {
-          Env = [
-            "SITE_CONTENT_DIR=${inputs.site-content}"
-            "STATIC_DIR=${config.flake.paths.root + /rs/site/static}"
+      packages = {
+        yt-meta = pkgs.writeShellApplication {
+          name = "yt-meta";
+          runtimeInputs = with pkgs; [
+            yt-dlp
+            jq
+            ffmpeg
+            deno
           ];
-          Entrypoint = [
-            "/bin/sh"
-            "-c"
+          text = ''
+            if [ "$#" -ne 1 ]; then
+              echo "usage: yt-meta <url>" >&2
+              exit 1
+            fi
+
+            url="$1"
+
+            yt-dlp \
+              --js-runtimes deno \
+              --remote-components ejs:npm \
+              -J "$url" \
+              | jq -r '
+                . as $v
+                | $v.title + ", "
+                + $v.uploader + ", "
+                + (
+                  if ($v.upload_date | type) == "string" and ($v.upload_date | test("^[0-9]{8}$"))
+                  then "\($v.upload_date[6:8])/\($v.upload_date[4:6])/\($v.upload_date[0:4])"
+                  else ""
+                  end
+                )
+              '
+          '';
+        };
+
+        site-bin = pkgs.rustPlatform.buildRustPackage {
+          name = "site";
+          src = config.flake.paths.root + /rs;
+          cargoLock.lockFile = config.flake.paths.root + /rs/Cargo.lock;
+        };
+
+        site-image = pkgs.dockerTools.buildLayeredImage {
+          name = "site";
+          tag = "latest";
+          contents = [
+            self'.packages.site-bin
+            pkgs.dockerTools.binSh
           ];
-          Cmd = [ "/bin/site" ];
+          config = {
+            Env = [
+              "SITE_CONTENT_DIR=${inputs.site-content}"
+              "STATIC_DIR=${config.flake.paths.root + /rs/site/static}"
+            ];
+            Entrypoint = [
+              "/bin/sh"
+              "-c"
+            ];
+            Cmd = [ "/bin/site" ];
+          };
         };
       };
     };

--- a/sessions/2026-02-21-yt-dlp-url-script.md
+++ b/sessions/2026-02-21-yt-dlp-url-script.md
@@ -40,3 +40,20 @@ User asked for research before implementation: can dependencies be scoped to the
 - Initial statix warning occurred due to repeated `packages.<name>` keys in `nix/outputs/packages.nix`.
 - Fixed by refactoring to a single `packages = { ... };` attrset.
 - Re-ran checks successfully.
+
+## Home Manager wiring
+
+- Added `yt-meta` to `home.packages` in `nix/modules/aliases.nix`.
+- Used flake-parts transposed package output keyed by host architecture:
+  - `cfg.packages.${pkgs.stdenv.hostPlatform.system}.yt-meta`
+- This keeps one declaration working across `x86_64-linux` and `aarch64-darwin` by selecting the current host system at evaluation time.
+
+## Live verification
+
+- Ran `just rb` (including `nh os switch .`) after wiring Home Manager package.
+- Switch output showed `yt-meta` integration artifacts (including fish completion derivation).
+- Verified command available on native PATH:
+  - `command -v yt-meta` -> `/home/rafiq/.nix-profile/bin/yt-meta`
+- Verified command output from PATH executable:
+  - `yt-meta "https://www.youtube.com/watch?v=9M7pKi-3o18"`
+  - `How Do Cultures Evolve? - featuring Edward Burnett Tylor — Anthropology Theory #1, a partial perspective, 13/12/2017`

--- a/sessions/2026-02-21-yt-dlp-url-script.md
+++ b/sessions/2026-02-21-yt-dlp-url-script.md
@@ -1,0 +1,42 @@
+# 2026-02-21 yt-dlp URL script
+
+## Task
+
+User asked for research before implementation: can dependencies be scoped to the command runtime instead of being installed broadly in `home.packages`.
+
+## Exploration
+
+- Reviewed current module: `nix/modules/aliases.nix`.
+- Reviewed existing script pattern: `scripts/process.sh`.
+- Searched web and docs for Nix script builders and runtime dependency handling.
+- Verified `writeShellApplication` behavior from Nixpkgs docs and Noogle implementation.
+
+## Findings
+
+- `pkgs.writeShellApplication` supports `runtimeInputs` and injects them into `PATH` only for that script runtime.
+- This allows adding a single generated package to `home.packages` while not adding each dependency as separate user-facing packages.
+- For yt-dlp warnings, `ffmpeg` and a JS runtime (recommended: `deno`) can be provided via `runtimeInputs`.
+- For current yt-dlp EJS guidance, runtime alone may not be enough in all packaging contexts; remote EJS components can be enabled via `--remote-components ejs:npm` (with deno/bun) or `ejs:github`.
+
+## Implementation
+
+- Implemented a standalone package in `nix/outputs/packages.nix` as `packages.yt-meta` using `pkgs.writeShellApplication`.
+- Added runtime-scoped inputs: `yt-dlp`, `jq`, `ffmpeg`, `deno`.
+- Script behavior:
+  - Requires one argument (`yt-meta <url>`).
+  - Runs `yt-dlp -J` with `--js-runtimes deno` and `--remote-components ejs:npm`.
+  - Formats output as values-only CSV-like line: `title, uploader, dd/mm/yyyy`.
+
+## Validation
+
+- Executed: `nix run .#yt-meta -- "https://www.youtube.com/watch?v=9M7pKi-3o18"`.
+- Observed output:
+  - `How Do Cultures Evolve? - featuring Edward Burnett Tylor — Anthropology Theory #1, a partial perspective, 13/12/2017`
+- Date conversion verified from source `upload_date=20171213` to `13/12/2017`.
+
+## Repo checks
+
+- Ran `just nice` and `just check`.
+- Initial statix warning occurred due to repeated `packages.<name>` keys in `nix/outputs/packages.nix`.
+- Fixed by refactoring to a single `packages = { ... };` attrset.
+- Re-ran checks successfully.


### PR DESCRIPTION
## Summary
- add a standalone flake package `yt-meta` in `nix/outputs/packages.nix` using `writeShellApplication` with runtime-scoped `yt-dlp`, `jq`, `ffmpeg`, and `deno`
- format output as `title, uploader, dd/mm/yyyy` and verify against `https://www.youtube.com/watch?v=9M7pKi-3o18`
- include `yt-meta` in Home Manager via `cfg.packages.${pkgs.stdenv.hostPlatform.system}.yt-meta` so it resolves correctly across host architectures
- document research, implementation, and verification in `sessions/2026-02-21-yt-dlp-url-script.md`

## Validation
- `just rb` (runs `just nice`, `just check`, then `nh os switch .`)
- `command -v yt-meta`
- `yt-meta "https://www.youtube.com/watch?v=9M7pKi-3o18"`