### PR TITLE
feat(nvim): add robust <leader>tm interstitial header flow

### DIFF
--- a/nvim/rafiq.lua
+++ b/nvim/rafiq.lua
@@ -60,6 +60,33 @@ local function create_note_from_picker_query()
 	edit_note(dir .. "/" .. name)
 end
 
+local function insert_interstitial_notes_header()
+	local row = vim.api.nvim_win_get_cursor(0)[1]
+	local timestamp = os.date("%H%Mhrs")
+	local bufnr = vim.api.nvim_get_current_buf()
+
+	vim.api.nvim_buf_set_lines(0, row, row, false, {
+		timestamp .. ":",
+		"- ",
+	})
+
+	vim.api.nvim_win_set_cursor(0, { row + 2, 2 })
+	vim.cmd("startinsert")
+
+	vim.api.nvim_create_autocmd("InsertLeave", {
+		buffer = bufnr,
+		once = true,
+		callback = function()
+			local leave_row = vim.api.nvim_win_get_cursor(0)[1]
+			local next_line = vim.api.nvim_buf_get_lines(bufnr, leave_row, leave_row + 1, false)[1]
+
+			if next_line ~= "" then
+				vim.api.nvim_buf_set_lines(bufnr, leave_row, leave_row, false, { "" })
+			end
+		end,
+	})
+end
+
 vim.api.nvim_create_autocmd("FileType", {
 	pattern = "fff_input",
 	callback = function(event)
@@ -154,6 +181,7 @@ end, { desc = "Pedia notes picker" })
 vim.keymap.set("n", "<leader>ra", [[:%s/\<\>//gI<Left><Left><Left>]], {
 	desc = "Change all file refs",
 })
+vim.keymap.set("n", "<leader>tm", insert_interstitial_notes_header, { desc = "Interstitial notes header" })
 vim.keymap.set("n", "<leader>tt", ":Yazi<CR>", { desc = "Open Yazi" })
 vim.keymap.set("n", "<leader>w", ":w ++p<CR>", { desc = "Write all" })
 vim.keymap.set("v", "<leader>y", '"+y', { desc = "Copy to system clipboard" })

--- a/sessions/2026-02-20-nvim-leader-tm-keymap.md
+++ b/sessions/2026-02-20-nvim-leader-tm-keymap.md
@@ -1,0 +1,27 @@
+# Session: nvim leader tm keymap behavior
+
+## Task
+- Update `<leader>tm` in `nvim/rafiq.lua` to always insert from column 1 and avoid brittle key-sequence behavior.
+- Move the blank separator line so it is added after leaving insert mode.
+
+## Work done
+- Added `insert_interstitial_notes_header()` and mapped `<leader>tm` to call it.
+- Implemented header insertion via Lua API (`nvim_buf_set_lines`) instead of command-string key simulation.
+- Inserted:
+  - `<HHMMhrs>:`
+  - `- `
+- Entered insert mode at the bullet line after `- `.
+- Added a one-shot, buffer-local `InsertLeave` autocmd to insert a trailing blank separator line when editing is done.
+
+## Reasoning and decisions
+- Replaced key-chord string logic to avoid edge cases like `<C-u>` deleting unintended content.
+- Kept insertion deterministic by writing explicit lines and cursor location.
+- Deferred separator creation to `InsertLeave` to match requested workflow.
+
+## Learning points
+- For editor automations, direct Neovim Lua buffer APIs are more predictable than long key translation strings.
+- Event hooks like `InsertLeave` are a clean way to apply post-edit formatting behavior.
+
+## Bugs encountered and solutions
+- Bug: `<C-u>`-based approach could remove line content when indentation was already absent.
+- Fix: switched to explicit Lua line insertion and removed `<C-u>` from the flow.


### PR DESCRIPTION
## Summary
- implement `<leader>tm` with a Lua function instead of a key-sequence string for deterministic behavior
- insert `HHMMhrs:` and `- ` at column 1, then enter insert mode at the bullet line
- add a one-shot `InsertLeave` hook to append the blank separator line after editing ends

## Notes
- includes session notes update for this task in `sessions/2026-02-20-nvim-leader-tm-keymap.md`