### PR TITLE
feat(rust): add peer autosync service for non-bare repos

### DIFF
--- a/nix/outputs/packages.nix
+++ b/nix/outputs/packages.nix
@@ -3,6 +3,24 @@
   perSystem =
     { pkgs, self', ... }:
     {
+      packages.git-peer-sync = pkgs.rustPlatform.buildRustPackage {
+        name = "git-peer-sync";
+        src = config.flake.paths.root + /rs;
+        cargoLock.lockFile = config.flake.paths.root + /rs/Cargo.lock;
+        cargoBuildFlags = [
+          "-p"
+          "git-peer-sync"
+        ];
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeCheckInputs = [ pkgs.git ];
+        postFixup = ''
+          wrapProgram "$out/bin/git-peer-sync" \
+            --prefix PATH : ${pkgs.lib.makeBinPath [
+              pkgs.git
+              pkgs.openssh
+            ]}
+        '';
+      };
       packages.site-bin = pkgs.rustPlatform.buildRustPackage {
         name = "site";
         src = config.flake.paths.root + /rs;

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -21,6 +21,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "askama"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +203,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -201,6 +263,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation-sys"
@@ -271,6 +379,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +439,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-peer-sync"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hostname",
+ "notify",
+ "tempfile",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +467,23 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"
@@ -479,6 +624,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +663,26 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -578,8 +769,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -596,6 +815,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
@@ -668,7 +893,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -700,7 +925,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -871,6 +1096,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,7 +1253,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1097,6 +1328,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "3"
-members = ["site"]
+members = ["git-peer-sync", "site"]

--- a/rs/git-peer-sync/Cargo.toml
+++ b/rs/git-peer-sync/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "git-peer-sync"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Watch a git repo, auto-commit changes, and sync peers"
+readme = "../../README.md"
+repository = "https://github.com/rrvsh/tools"
+keywords = ["git", "sync", "watcher"]
+categories = ["command-line-utilities"]
+
+[dependencies]
+anyhow = "1.0.100"
+clap = { version = "4.5.48", features = ["derive"] }
+hostname = "0.4.1"
+notify = "8.2.0"
+
+[dev-dependencies]
+tempfile = "3.24.0"
+
+[lints.clippy]
+correctness = "deny"
+suspicious = "deny"
+complexity = "deny"
+perf = "deny"
+style = "deny"
+pedantic = "deny"
+cargo = "deny"
+nursery = "deny"
+multiple-crate-versions = "allow"

--- a/rs/git-peer-sync/src/lib.rs
+++ b/rs/git-peer-sync/src/lib.rs
@@ -1,0 +1,472 @@
+#![allow(clippy::multiple_crate_versions)]
+
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus};
+use std::sync::mpsc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use notify::{Event, RecursiveMode, Watcher};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Peer {
+    pub name: String,
+    pub url: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct SyncConfig {
+    pub repo: PathBuf,
+    pub branch: String,
+    pub peers: Vec<Peer>,
+}
+
+/// Runs one full autosync cycle for a repository.
+///
+/// # Errors
+/// Returns an error if git commands fail, peer sync fails, or conflict handling fails.
+pub fn sync_once(config: &SyncConfig) -> Result<()> {
+    ensure_repo_exists(&config.repo)?;
+    auto_commit_if_needed(config)?;
+
+    for peer in &config.peers {
+        sync_peer(config, peer)
+            .with_context(|| format!("failed while syncing peer '{}'", peer.name))?;
+    }
+
+    Ok(())
+}
+
+/// Watches the repository and runs autosync after debounce intervals.
+///
+/// # Errors
+/// Returns an error if watcher setup fails or the watcher channel disconnects.
+pub fn watch_and_sync(config: &SyncConfig, debounce: Duration) -> Result<()> {
+    ensure_repo_exists(&config.repo)?;
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = notify::recommended_watcher(move |result: notify::Result<Event>| {
+        let _ = tx.send(result);
+    })
+    .context("failed to create filesystem watcher")?;
+
+    watcher
+        .watch(&config.repo, RecursiveMode::Recursive)
+        .with_context(|| format!("failed to watch '{}'", config.repo.display()))?;
+
+    let mut pending = false;
+    let mut last_event_at = Instant::now();
+
+    loop {
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(Ok(event)) => {
+                if !event.paths.iter().any(|path| is_git_internal_path(path)) {
+                    pending = true;
+                    last_event_at = Instant::now();
+                }
+            }
+            Ok(Err(err)) => {
+                eprintln!("watcher error: {err}");
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if pending && last_event_at.elapsed() >= debounce {
+                    if let Err(err) = sync_once(config) {
+                        eprintln!("sync failed: {err:#}");
+                    }
+                    pending = false;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                bail!("watcher channel disconnected")
+            }
+        }
+    }
+}
+
+#[must_use]
+pub fn build_ssh_peers(repo: &Path, hosts: &[String]) -> Vec<Peer> {
+    hosts
+        .iter()
+        .map(|host| Peer {
+            name: host.clone(),
+            url: format!("ssh://{host}{}", repo.display()),
+        })
+        .collect()
+}
+
+fn sync_peer(config: &SyncConfig, peer: &Peer) -> Result<()> {
+    let remote_name = remote_name_for_peer(&peer.name);
+    ensure_remote(&config.repo, &remote_name, &peer.url)?;
+
+    let pull = run_git(
+        &config.repo,
+        [
+            "pull",
+            "--rebase",
+            remote_name.as_str(),
+            config.branch.as_str(),
+        ],
+    )?;
+    if !pull.status.success() {
+        if is_missing_remote_branch_error(&pull.stderr) {
+            // First-time sync to a new peer branch. Continue with push.
+        } else if has_unmerged_paths(&config.repo)? {
+            write_merge_conflict_file(config, peer, &pull)?;
+            let _ = run_git(&config.repo, ["rebase", "--abort"]);
+            bail!("rebase conflict with peer '{}'", peer.name);
+        } else {
+            bail!(
+                "git pull --rebase failed for peer '{}': {}",
+                peer.name,
+                String::from_utf8_lossy(&pull.stderr)
+            );
+        }
+    }
+
+    let push = run_git(
+        &config.repo,
+        ["push", remote_name.as_str(), config.branch.as_str()],
+    )?;
+    if !push.status.success() {
+        bail!(
+            "git push failed for peer '{}': {}",
+            peer.name,
+            String::from_utf8_lossy(&push.stderr)
+        );
+    }
+
+    Ok(())
+}
+
+fn ensure_repo_exists(repo: &Path) -> Result<()> {
+    if !repo.exists() {
+        bail!("repo path does not exist: {}", repo.display());
+    }
+
+    let output = run_git(repo, ["rev-parse", "--git-dir"])?;
+    if !output.status.success() {
+        bail!("path is not a git repository: {}", repo.display());
+    }
+    Ok(())
+}
+
+fn auto_commit_if_needed(config: &SyncConfig) -> Result<()> {
+    let add = run_git(&config.repo, ["add", "-A"])?;
+    if !add.status.success() {
+        bail!(
+            "git add -A failed: {}",
+            String::from_utf8_lossy(&add.stderr)
+        );
+    }
+
+    let status = run_git(&config.repo, ["status", "--porcelain"])?;
+    if !status.status.success() {
+        bail!(
+            "git status --porcelain failed: {}",
+            String::from_utf8_lossy(&status.stderr)
+        );
+    }
+
+    if status.stdout.is_empty() {
+        return Ok(());
+    }
+
+    let host = hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| String::from("unknown-host"));
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let message = format!("autosync: {host} {now}");
+
+    let commit = run_git(&config.repo, ["commit", "-m", message.as_str()])?;
+    if !commit.status.success() {
+        bail!(
+            "git commit failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
+    }
+
+    Ok(())
+}
+
+fn ensure_remote(repo: &Path, remote_name: &str, remote_url: &str) -> Result<()> {
+    let get_url = run_git(repo, ["remote", "get-url", remote_name])?;
+    if get_url.status.success() {
+        let existing = String::from_utf8_lossy(&get_url.stdout).trim().to_string();
+        if existing != remote_url {
+            let set_url = run_git(repo, ["remote", "set-url", remote_name, remote_url])?;
+            if !set_url.status.success() {
+                bail!(
+                    "failed to update remote '{remote_name}': {}",
+                    String::from_utf8_lossy(&set_url.stderr)
+                );
+            }
+        }
+        return Ok(());
+    }
+
+    let add = run_git(repo, ["remote", "add", remote_name, remote_url])?;
+    if !add.status.success() {
+        bail!(
+            "failed to add remote '{remote_name}': {}",
+            String::from_utf8_lossy(&add.stderr)
+        );
+    }
+
+    Ok(())
+}
+
+fn has_unmerged_paths(repo: &Path) -> Result<bool> {
+    let output = run_git(repo, ["ls-files", "-u"])?;
+    if !output.status.success() {
+        bail!(
+            "git ls-files -u failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(!output.stdout.is_empty())
+}
+
+fn write_merge_conflict_file(config: &SyncConfig, peer: &Peer, pull: &GitOutput) -> Result<()> {
+    let conflict_path = config.repo.join("MERGE_CONFLICT");
+
+    let status = run_git(&config.repo, ["status", "--short"])?;
+    let unresolved = run_git(&config.repo, ["diff", "--name-only", "--diff-filter=U"])?;
+    let conflict_diff = run_git(&config.repo, ["diff", "--merge"])?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let content = format!(
+        "conflict_at_unix={now}\npeer={}\nbranch={}\n\n[pull_stderr]\n{}\n\n[status_short]\n{}\n\n[unmerged_files]\n{}\n\n[conflict_diff]\n{}\n",
+        peer.name,
+        config.branch,
+        String::from_utf8_lossy(&pull.stderr),
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&unresolved.stdout),
+        String::from_utf8_lossy(&conflict_diff.stdout)
+    );
+
+    fs::write(&conflict_path, content)
+        .with_context(|| format!("failed to write '{}'", conflict_path.display()))?;
+
+    Ok(())
+}
+
+fn is_git_internal_path(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == OsStr::new(".git"))
+}
+
+fn is_missing_remote_branch_error(stderr: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(stderr);
+    text.contains("couldn't find remote ref") || text.contains("no such ref was fetched")
+}
+
+fn remote_name_for_peer(peer: &str) -> String {
+    let mut out = String::from("peer-");
+    for ch in peer.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '-' {
+            out.push(ch);
+        } else {
+            out.push('-');
+        }
+    }
+    out
+}
+
+struct GitOutput {
+    status: ExitStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+fn run_git<I, S>(repo: &Path, args: I) -> Result<GitOutput>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .with_context(|| format!("failed to execute git in '{}'", repo.display()))?;
+
+    Ok(GitOutput {
+        status: output.status,
+        stdout: output.stdout,
+        stderr: output.stderr,
+    })
+}
+
+#[must_use]
+pub fn parse_hosts_list(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+/// Builds a validated [`SyncConfig`] using SSH host peers.
+///
+/// # Errors
+/// Returns an error when no hosts are provided.
+pub fn build_config_for_hosts(repo: &Path, branch: &str, hosts: &[String]) -> Result<SyncConfig> {
+    if hosts.is_empty() {
+        bail!("at least one host is required");
+    }
+
+    Ok(SyncConfig {
+        repo: repo.to_path_buf(),
+        branch: branch.to_string(),
+        peers: build_ssh_peers(repo, hosts),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    use tempfile::TempDir;
+
+    #[test]
+    fn parses_hosts_list() {
+        let hosts = parse_hosts_list("alpha, beta ,,gamma");
+        assert_eq!(hosts, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn sanitizes_remote_name() {
+        let remote = remote_name_for_peer("alpha.local:2222");
+        assert_eq!(remote, "peer-alpha-local-2222");
+    }
+
+    #[test]
+    fn sync_once_pushes_to_peer_non_bare_repo() -> Result<()> {
+        let temp = TempDir::new()?;
+        let repo_a = temp.path().join("a");
+        let repo_b = temp.path().join("b");
+        fs::create_dir_all(&repo_a)?;
+        fs::create_dir_all(&repo_b)?;
+
+        init_repo(&repo_a)?;
+        init_repo(&repo_b)?;
+        configure_receive_update_instead(&repo_a)?;
+        configure_receive_update_instead(&repo_b)?;
+
+        fs::write(repo_a.join("note.txt"), "v1\n")?;
+        git(&repo_a, ["add", "note.txt"])?;
+        git(&repo_a, ["commit", "-m", "initial"])?;
+
+        let config = SyncConfig {
+            repo: repo_a.clone(),
+            branch: String::from("main"),
+            peers: vec![Peer {
+                name: String::from("b"),
+                url: repo_b.display().to_string(),
+            }],
+        };
+
+        sync_once(&config)?;
+
+        fs::write(repo_a.join("note.txt"), "v2\n")?;
+        sync_once(&config)?;
+
+        let content_b = fs::read_to_string(repo_b.join("note.txt"))?;
+        assert_eq!(content_b, "v2\n");
+        Ok(())
+    }
+
+    #[test]
+    fn writes_merge_conflict_file_on_rebase_conflict() -> Result<()> {
+        let temp = TempDir::new()?;
+        let repo_a = temp.path().join("a");
+        let repo_b = temp.path().join("b");
+        fs::create_dir_all(&repo_a)?;
+        fs::create_dir_all(&repo_b)?;
+
+        init_repo(&repo_a)?;
+        init_repo(&repo_b)?;
+        configure_receive_update_instead(&repo_a)?;
+        configure_receive_update_instead(&repo_b)?;
+
+        fs::write(repo_a.join("shared.txt"), "base\n")?;
+        git(&repo_a, ["add", "shared.txt"])?;
+        git(&repo_a, ["commit", "-m", "base"])?;
+
+        git(
+            &repo_a,
+            ["remote", "add", "seed", repo_b.to_str().unwrap_or("")],
+        )?;
+        git(&repo_a, ["push", "seed", "main"])?;
+
+        fs::write(repo_a.join("shared.txt"), "from-a\n")?;
+        git(&repo_a, ["add", "shared.txt"])?;
+        git(&repo_a, ["commit", "-m", "a-change"])?;
+
+        fs::write(repo_b.join("shared.txt"), "from-b\n")?;
+        git(&repo_b, ["add", "shared.txt"])?;
+        git(&repo_b, ["commit", "-m", "b-change"])?;
+
+        let config = SyncConfig {
+            repo: repo_a.clone(),
+            branch: String::from("main"),
+            peers: vec![Peer {
+                name: String::from("b"),
+                url: repo_b.display().to_string(),
+            }],
+        };
+
+        let result = sync_once(&config);
+        assert!(result.is_err());
+
+        let conflict_file = repo_a.join("MERGE_CONFLICT");
+        assert!(conflict_file.exists());
+
+        let conflict_content = fs::read_to_string(conflict_file)?;
+        assert!(conflict_content.contains("peer=b"));
+        assert!(conflict_content.contains("shared.txt"));
+
+        Ok(())
+    }
+
+    fn init_repo(repo: &Path) -> Result<()> {
+        git(repo, ["init", "-b", "main"])?;
+        git(repo, ["config", "user.email", "tests@example.com"])?;
+        git(repo, ["config", "user.name", "Test User"])?;
+        Ok(())
+    }
+
+    fn configure_receive_update_instead(repo: &Path) -> Result<()> {
+        git(
+            repo,
+            ["config", "receive.denyCurrentBranch", "updateInstead"],
+        )?;
+        git(repo, ["config", "receive.denyNonFastForwards", "true"])?;
+        git(repo, ["config", "receive.denyDeletes", "true"])?;
+        Ok(())
+    }
+
+    fn git<I, S>(repo: &Path, args: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let status = Command::new("git").args(args).current_dir(repo).status()?;
+        if !status.success() {
+            return Err(anyhow::anyhow!("git command failed in {}", repo.display()));
+        }
+        Ok(())
+    }
+}

--- a/rs/git-peer-sync/src/main.rs
+++ b/rs/git-peer-sync/src/main.rs
@@ -1,0 +1,117 @@
+#![allow(clippy::multiple_crate_versions)]
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use clap::{Parser, Subcommand};
+use git_peer_sync::{
+    build_config_for_hosts, parse_hosts_list, sync_once, watch_and_sync, Peer, SyncConfig,
+};
+
+#[derive(Debug, Parser)]
+#[command(name = "git-peer-sync")]
+#[command(about = "Auto-commit and sync a git repository across peer devices")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    Watch {
+        #[arg(long)]
+        repo: PathBuf,
+        #[arg(long, default_value = "main")]
+        branch: String,
+        #[arg(long, value_name = "HOSTS_CSV")]
+        hosts: Option<String>,
+        #[arg(long = "peer-url", value_name = "NAME=URL")]
+        peer_urls: Vec<String>,
+        #[arg(long, default_value_t = 10)]
+        debounce_seconds: u64,
+    },
+    SyncOnce {
+        #[arg(long)]
+        repo: PathBuf,
+        #[arg(long, default_value = "main")]
+        branch: String,
+        #[arg(long, value_name = "HOSTS_CSV")]
+        hosts: Option<String>,
+        #[arg(long = "peer-url", value_name = "NAME=URL")]
+        peer_urls: Vec<String>,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Watch {
+            repo,
+            branch,
+            hosts,
+            peer_urls,
+            debounce_seconds,
+        } => {
+            let config = config_from_args(&repo, &branch, hosts.as_deref(), &peer_urls)?;
+            watch_and_sync(&config, Duration::from_secs(debounce_seconds))
+        }
+        Commands::SyncOnce {
+            repo,
+            branch,
+            hosts,
+            peer_urls,
+        } => {
+            let config = config_from_args(&repo, &branch, hosts.as_deref(), &peer_urls)?;
+            sync_once(&config)
+        }
+    }
+}
+
+fn config_from_args(
+    repo: &Path,
+    branch: &str,
+    hosts_csv: Option<&str>,
+    peer_urls: &[String],
+) -> Result<SyncConfig> {
+    if !peer_urls.is_empty() {
+        let peers = parse_named_peer_urls(peer_urls)?;
+        return Ok(SyncConfig {
+            repo: repo.to_path_buf(),
+            branch: branch.to_string(),
+            peers,
+        });
+    }
+
+    let Some(hosts_csv) = hosts_csv else {
+        bail!("either --hosts or one or more --peer-url entries are required")
+    };
+
+    let hosts = parse_hosts_list(hosts_csv);
+    build_config_for_hosts(repo, branch, &hosts)
+        .with_context(|| format!("invalid host configuration for repo '{}'", repo.display()))
+}
+
+fn parse_named_peer_urls(entries: &[String]) -> Result<Vec<Peer>> {
+    let mut peers = Vec::with_capacity(entries.len());
+
+    for entry in entries {
+        let Some((name, url)) = entry.split_once('=') else {
+            bail!("invalid --peer-url '{entry}'; expected NAME=URL")
+        };
+
+        let name = name.trim();
+        let url = url.trim();
+        if name.is_empty() || url.is_empty() {
+            bail!("invalid --peer-url '{entry}'; NAME and URL are required");
+        }
+
+        peers.push(Peer {
+            name: name.to_string(),
+            url: url.to_string(),
+        });
+    }
+
+    Ok(peers)
+}

--- a/sessions/2026-02-21-two-way-git-sync-plan.md
+++ b/sessions/2026-02-21-two-way-git-sync-plan.md
@@ -1,0 +1,74 @@
+## Task
+
+Provide a practical plan for two-way Git sync where two non-bare repositories can push and pull directly from each other.
+
+## Retrieval-led notes
+
+- Reviewed `.agents/skills/web-search/SKILL.md` and used `ddgr` web search for relevant Git docs.
+- Verified behavior in `git-config` docs for `receive.denyCurrentBranch=updateInstead` and clean worktree requirement.
+- Reviewed `githooks` docs for `push-to-checkout` hook behavior with `updateInstead`.
+
+## Decisions
+
+- Recommend using `receive.denyCurrentBranch=updateInstead` on both devices.
+- Recommend branch protection settings that reduce accidental history rewrites (`receive.denyNonFastForwards=true`, `receive.denyDeletes=true`).
+- Recommend a symmetric workflow: commit -> pull --rebase from peer -> push to peer.
+
+## Risks and mitigations
+
+- Push to checked-out branch fails if remote worktree is dirty under `updateInstead`.
+  - Mitigation: keep both repos clean before sync, or use a dedicated sync branch.
+- Concurrent independent commits can diverge.
+  - Mitigation: always pull/rebase before push and resolve conflicts locally.
+
+## Outcome
+
+- Prepared concise setup + operating plan and troubleshooting checklist for user.
+
+## Follow-up implementation
+
+### Goal
+
+Implement a Rust crate/service that watches a repo, auto-commits changes, syncs to peers, and writes `MERGE_CONFLICT` with diff summary on rebase conflicts.
+
+### Work breakdown
+
+- Added new workspace crate: `rs/git-peer-sync`.
+- Implemented sync engine in `rs/git-peer-sync/src/lib.rs`:
+  - `sync_once` to stage/commit and sync peers.
+  - `watch_and_sync` with `notify` recursive watcher and debounce.
+  - Peer sync via `git pull --rebase` then `git push`.
+  - Conflict detection (`git ls-files -u`) and `MERGE_CONFLICT` writing.
+  - Rebase abort after conflict summary capture.
+- Implemented CLI in `rs/git-peer-sync/src/main.rs`:
+  - `watch` and `sync-once` commands.
+  - Supports both `--hosts` (ssh hostnames, same repo path) and `--peer-url NAME=URL` overrides.
+- Added workspace member in `rs/Cargo.toml`.
+- Updated Nix packages output in `nix/outputs/packages.nix`:
+  - Added `packages.git-peer-sync` via `buildRustPackage`.
+  - Added runtime wrapper PATH for `git` and `openssh`.
+  - Added `nativeCheckInputs = [ pkgs.git ]` so tests can execute git in sandbox.
+
+### Bugs encountered and fixes
+
+- **Watcher path type mismatch (`&PathBuf` vs `&Path`)**
+  - Fixed by using closure adapter in `.any(|path| is_git_internal_path(path))`.
+- **First push to empty peer branch failed (`couldn't find remote ref main`)**
+  - Added explicit detection for missing-remote-branch pull error and allowed initial push to continue.
+- **Nix package build failed: crate path missing in source**
+  - Root cause: untracked files are excluded from flake source snapshots.
+  - Fixed by staging new crate files before Nix build test.
+- **Nix package check failed: tests couldn't find `git` in sandbox**
+  - Fixed by adding `nativeCheckInputs = [ pkgs.git ]`.
+- **Strict clippy failures from repository lint policy**
+  - Added missing crate metadata, docs for `Result` APIs, `#[must_use]` where required, and formatted error strings.
+  - Added `#![allow(clippy::multiple_crate_versions)]` to handle unavoidable transitive version duplication.
+
+### Validation performed
+
+- `cargo test --manifest-path rs/Cargo.toml -p git-peer-sync` passed.
+- `cargo clippy --manifest-path rs/Cargo.toml -p git-peer-sync --all-targets` passed.
+- `nix build .#git-peer-sync` passed after packaging fixes.
+- Manual runtime verification with temporary repos:
+  - Success path: `sync-once` auto-commit + push updates peer non-bare repo.
+  - Conflict path: `sync-once` exits non-zero and creates `MERGE_CONFLICT` containing peer, file list, status, and conflict diff.


### PR DESCRIPTION
## Summary
- add a new `git-peer-sync` Rust crate that watches a repository, auto-commits local changes, and syncs peers via `pull --rebase` + `push`
- implement rebase conflict handling that writes a `MERGE_CONFLICT` file with pull stderr, unmerged files, status, and conflict diff summary
- package the tool in Nix as `packages.git-peer-sync` with wrapped runtime dependencies (`git`, `openssh`) and sandbox test support
- include crate tests that validate push/pull behavior against non-bare repos and conflict-file creation

## Verification
- `cargo test --manifest-path rs/Cargo.toml -p git-peer-sync`
- `cargo clippy --manifest-path rs/Cargo.toml -p git-peer-sync --all-targets`
- `nix build .#git-peer-sync`
- manual temp-dir runs of `sync-once` for both successful sync and rebase-conflict paths