### PR TITLE
feat: add Mixxx DJ software with cross-platform support

### DIFF
--- a/nix/modules/desktop/audio-mixxx.nix
+++ b/nix/modules/desktop/audio-mixxx.nix
@@ -1,7 +1,11 @@
+{ lib, ... }:
 {
   config.flake.modules.homeManager.rafiq =
     { pkgs, ... }:
     {
-      home.packages = [ pkgs.mixxx ];
+      home.packages = lib.optional pkgs.stdenv.isLinux pkgs.mixxx;
     };
+  config.flake.modules.darwin.rafiq = {
+    homebrew.casks = [ "mixxx" ];
+  };
 }

--- a/nix/modules/desktop/audio-mixxx.nix
+++ b/nix/modules/desktop/audio-mixxx.nix
@@ -1,0 +1,7 @@
+{
+  config.flake.modules.homeManager.rafiq =
+    { pkgs, ... }:
+    {
+      home.packages = [ pkgs.mixxx ];
+    };
+}


### PR DESCRIPTION
## Summary

- Add Mixxx DJ software as a home-manager package (Linux) via `nix/modules/desktop/audio-mixxx.nix`
- Make it cross-platform: Linux installs via nixpkgs, macOS installs via Homebrew cask