### PR TITLE
feat(site): add browser-local EPUB reader

### DIFF
--- a/.opencode/plans/epub-reader-implementation.md
+++ b/.opencode/plans/epub-reader-implementation.md
@@ -35,6 +35,10 @@ Delivery Plan (atomic commits)
    - Add index link to `/reader`.
    - Reader-specific CSS aligned with existing style.
    - Mobile layout pass and UX polish.
+   - Status: completed.
+
+Overall status
+- Implementation complete.
 
 Execution log
 - 2026-04-01: Plan initialized.
@@ -42,3 +46,4 @@ Execution log
 - 2026-04-01: Commit 1 completed after green checks.
 - 2026-04-01: Commit 2 completed (IndexedDB + library overlay + routing skeleton).
 - 2026-04-01: Commit 3 completed (epub rendering + progress + bookmarks).
+- 2026-04-01: Commit 4 completed (site integration + polish).

--- a/.opencode/plans/epub-reader-implementation.md
+++ b/.opencode/plans/epub-reader-implementation.md
@@ -22,6 +22,7 @@ Delivery Plan (atomic commits)
    - IndexedDB setup (`books`, `progress` stores).
    - Library overlay for import/open/delete.
    - Hash-based router (`#bookId` and `#bookId/cfi=...`).
+   - Status: completed.
 
 3) Reader rendering and persistence
    - epub.js continuous scroll rendition.
@@ -38,3 +39,4 @@ Execution log
 - 2026-04-01: Plan initialized.
 - 2026-04-01: Commit 1 implementation started (route + handler + template shell).
 - 2026-04-01: Commit 1 completed after green checks.
+- 2026-04-01: Commit 2 completed (IndexedDB + library overlay + routing skeleton).

--- a/.opencode/plans/epub-reader-implementation.md
+++ b/.opencode/plans/epub-reader-implementation.md
@@ -1,0 +1,40 @@
+EPUB Reader Implementation Plan
+
+Branch: feat/epub-reader-browser-storage
+Status: in progress
+
+Objectives
+- Add a public `/reader` single-page EPUB reader route.
+- Store EPUB binaries in IndexedDB in-browser storage.
+- Render books in a continuous scroll reading mode.
+- Track reading progress and bookmarks per book.
+- Use hash routing for deep-linking and refresh safety.
+- Keep styling aligned with existing site dark aesthetic.
+
+Delivery Plan (atomic commits)
+1) Reader route and page shell
+   - Add `reader` controller and route wiring.
+   - Add `reader.html` template shell with app mount.
+   - Add links for `reader.css` and `reader.js` plus CDN libraries.
+   - Status: completed.
+
+2) Reader frontend core (library + storage + routing)
+   - IndexedDB setup (`books`, `progress` stores).
+   - Library overlay for import/open/delete.
+   - Hash-based router (`#bookId` and `#bookId/cfi=...`).
+
+3) Reader rendering and persistence
+   - epub.js continuous scroll rendition.
+   - Save/restore CFI progress.
+   - Bookmark create/list/jump/delete.
+   - Reading progress indicator.
+
+4) Site integration and polish
+   - Add index link to `/reader`.
+   - Reader-specific CSS aligned with existing style.
+   - Mobile layout pass and UX polish.
+
+Execution log
+- 2026-04-01: Plan initialized.
+- 2026-04-01: Commit 1 implementation started (route + handler + template shell).
+- 2026-04-01: Commit 1 completed after green checks.

--- a/.opencode/plans/epub-reader-implementation.md
+++ b/.opencode/plans/epub-reader-implementation.md
@@ -29,6 +29,7 @@ Delivery Plan (atomic commits)
    - Save/restore CFI progress.
    - Bookmark create/list/jump/delete.
    - Reading progress indicator.
+   - Status: completed.
 
 4) Site integration and polish
    - Add index link to `/reader`.
@@ -40,3 +41,4 @@ Execution log
 - 2026-04-01: Commit 1 implementation started (route + handler + template shell).
 - 2026-04-01: Commit 1 completed after green checks.
 - 2026-04-01: Commit 2 completed (IndexedDB + library overlay + routing skeleton).
+- 2026-04-01: Commit 3 completed (epub rendering + progress + bookmarks).

--- a/rs/site/src/app/controllers/mod.rs
+++ b/rs/site/src/app/controllers/mod.rs
@@ -1,5 +1,6 @@
 mod article;
 mod index;
+mod reader;
 
 use crate::app::state::AppState;
 use axum::routing::get;
@@ -15,6 +16,7 @@ pub fn build_router(state: Arc<AppState>, content_dir: &str, static_dir: &str) -
         .nest_service("/static", ServeDir::new(static_dir))
         .nest_service("/assets", ServeDir::new(assets_dir))
         .route("/", get(index::get))
+        .route("/reader", get(reader::get))
         .route("/{year}/{month}/{day}/{slug}", get(article::get))
         .with_state(state)
 }

--- a/rs/site/src/app/controllers/reader.rs
+++ b/rs/site/src/app/controllers/reader.rs
@@ -1,0 +1,16 @@
+use askama::Template;
+use axum::{
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
+};
+
+#[derive(Template)]
+#[template(path = "reader.html")]
+struct ReaderTemplate {}
+
+pub async fn get() -> Result<Response, StatusCode> {
+    ReaderTemplate {}.render().map_or_else(
+        |_| Err(StatusCode::INTERNAL_SERVER_ERROR),
+        |rendered| Ok(Html(rendered).into_response()),
+    )
+}

--- a/rs/site/static/reader.css
+++ b/rs/site/static/reader.css
@@ -1,5 +1,6 @@
 .reader-page {
   width: min(960px, calc(100vw - 40px));
+  backdrop-filter: blur(2px);
 }
 
 .reader-app {
@@ -13,6 +14,11 @@
   padding: 16px;
   margin-bottom: 12px;
   background-color: rgba(0, 0, 0, 0.92);
+}
+
+#epub-file-input {
+  margin: 6px 0 10px;
+  width: 100%;
 }
 
 .book-list,
@@ -70,6 +76,7 @@
   border: 1px solid #666;
   border-radius: 10px;
   padding: 10px;
+  background: #050505;
 }
 
 .reader-placeholder,

--- a/rs/site/static/reader.css
+++ b/rs/site/static/reader.css
@@ -1,0 +1,94 @@
+.reader-page {
+  width: min(960px, calc(100vw - 40px));
+}
+
+.reader-app {
+  min-height: 60vh;
+}
+
+.reader-overlay,
+.reader-view {
+  border: 2px solid white;
+  border-radius: 15px;
+  padding: 16px;
+  margin-bottom: 12px;
+  background-color: rgba(0, 0, 0, 0.92);
+}
+
+.book-list,
+.bookmark-list {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+}
+
+.book-item {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #555;
+}
+
+.book-title {
+  font-weight: bold;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.book-meta {
+  grid-column: 3;
+  font-size: 0.9rem;
+  color: #b5b5b5;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.reader-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.reading-progress {
+  margin-left: auto;
+}
+
+.bookmarks-panel {
+  border: 1px solid #666;
+  border-radius: 10px;
+  padding: 8px;
+  margin-bottom: 10px;
+}
+
+.reader-container {
+  min-height: 55vh;
+  border: 1px solid #666;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.reader-placeholder,
+.reader-error,
+.empty {
+  color: #d4d4d4;
+}
+
+@media (max-width: 700px) {
+  .book-item {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .book-title,
+  .book-meta {
+    grid-column: 1 / -1;
+  }
+
+  .reading-progress {
+    margin-left: 0;
+  }
+}

--- a/rs/site/static/reader.js
+++ b/rs/site/static/reader.js
@@ -6,6 +6,9 @@ const PROGRESS_STORE = "progress";
 let db = null;
 let currentBookId = null;
 let routeToken = 0;
+let activeBook = null;
+let activeRendition = null;
+let saveCfiTimer = null;
 
 const dom = {
   fileInput: document.querySelector("#epub-file-input"),
@@ -13,6 +16,8 @@ const dom = {
   readerOverlay: document.querySelector("#reader-overlay"),
   readerView: document.querySelector("#reader-view"),
   readerContainer: document.querySelector("#reader-container"),
+  bookmarksPanel: document.querySelector("#bookmarks-panel"),
+  bookmarkList: document.querySelector("#bookmark-list"),
   openLibraryButton: document.querySelector("#open-library"),
   addBookmarkButton: document.querySelector("#add-bookmark"),
   showBookmarksButton: document.querySelector("#show-bookmarks"),
@@ -138,22 +143,40 @@ function parseHash() {
 }
 
 function setHash(bookId, cfi = "") {
+  const nextHash = bookId
+    ? cfi
+      ? `#${bookId}/cfi=${encodeCfi(cfi)}`
+      : `#${bookId}`
+    : "";
+
+  if (window.location.hash === nextHash) {
+    return;
+  }
+
+  window.location.hash = nextHash;
+}
+
+function replaceHash(bookId, cfi = "") {
   if (!bookId) {
-    window.location.hash = "";
+    window.history.replaceState(null, "", window.location.pathname);
     return;
   }
 
   if (cfi) {
-    window.location.hash = `#${bookId}/cfi=${encodeCfi(cfi)}`;
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}#${bookId}/cfi=${encodeCfi(cfi)}`,
+    );
     return;
   }
 
-  window.location.hash = `#${bookId}`;
+  window.history.replaceState(null, "", `${window.location.pathname}#${bookId}`);
 }
 
 function disableFutureControlsUntilRender() {
-  dom.addBookmarkButton.disabled = true;
-  dom.showBookmarksButton.disabled = true;
+  dom.addBookmarkButton.disabled = false;
+  dom.showBookmarksButton.disabled = false;
 }
 
 function showError(message) {
@@ -177,6 +200,237 @@ function renderOpenBookPlaceholder(book, progress) {
       <p>${progressLabel}</p>
     </div>
   `;
+}
+
+async function saveProgress(bookId, patch) {
+  const existing = (await getProgressByBookId(bookId)) ?? {
+    bookId,
+    cfi: "",
+    bookmarks: [],
+  };
+
+  const nextValue = {
+    ...existing,
+    ...patch,
+  };
+
+  return withStore(PROGRESS_STORE, "readwrite", (store) => requestToPromise(store.put(nextValue)));
+}
+
+function debounceSaveCfi(bookId, cfi) {
+  if (!bookId || !cfi) {
+    return;
+  }
+
+  if (saveCfiTimer) {
+    window.clearTimeout(saveCfiTimer);
+  }
+
+  saveCfiTimer = window.setTimeout(async () => {
+    await saveProgress(bookId, { cfi });
+    replaceHash(bookId, cfi);
+  }, 500);
+}
+
+function normalizeBookmarks(progress) {
+  if (!progress || !Array.isArray(progress.bookmarks)) {
+    return [];
+  }
+
+  return progress.bookmarks;
+}
+
+function computeLabelFromProgress(percentage) {
+  const safe = Number.isFinite(percentage) ? Math.min(1, Math.max(0, percentage)) : 0;
+  const rounded = Math.round(safe * 100);
+  return `${rounded}%`;
+}
+
+async function renderBookmarksPanel(bookId) {
+  const progress = await getProgressByBookId(bookId);
+  const bookmarks = normalizeBookmarks(progress);
+
+  if (!bookmarks.length) {
+    dom.bookmarkList.innerHTML = "<li class=\"empty\">No bookmarks yet.</li>";
+    return;
+  }
+
+  const markup = bookmarks
+    .map(
+      (bookmark) => `
+        <li class="book-item">
+          <button class="button jump-bookmark" data-jump-bookmark-id="${bookmark.id}">Go</button>
+          <button class="button delete-bookmark" data-delete-bookmark-id="${bookmark.id}">Delete</button>
+          <span class="book-title">${escapeHtml(bookmark.label)}</span>
+          <span class="book-meta">${new Date(bookmark.createdAt).toLocaleString()}</span>
+        </li>
+      `,
+    )
+    .join("");
+
+  dom.bookmarkList.innerHTML = markup;
+}
+
+async function addBookmarkForCurrentBook() {
+  if (!activeRendition || !currentBookId) {
+    return;
+  }
+
+  const location = activeRendition.currentLocation();
+  const cfi = location?.start?.cfi;
+  if (!cfi) {
+    return;
+  }
+
+  const progress = await getProgressByBookId(currentBookId);
+  const bookmarks = normalizeBookmarks(progress);
+  const percentage = activeBook?.locations ? activeBook.locations.percentageFromCfi(cfi) : 0;
+  const label = `Bookmark ${computeLabelFromProgress(percentage)}`;
+  const bookmark = {
+    id: crypto.randomUUID(),
+    cfi,
+    label,
+    createdAt: Date.now(),
+  };
+
+  await saveProgress(currentBookId, {
+    cfi,
+    bookmarks: [bookmark, ...bookmarks],
+  });
+
+  await renderBookmarksPanel(currentBookId);
+}
+
+async function onBookmarkListClick(event) {
+  if (!currentBookId) {
+    return;
+  }
+
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  const progress = await getProgressByBookId(currentBookId);
+  const bookmarks = normalizeBookmarks(progress);
+
+  const jumpId = target.getAttribute("data-jump-bookmark-id");
+  if (jumpId) {
+    const bookmark = bookmarks.find((entry) => entry.id === jumpId);
+    if (bookmark?.cfi && activeRendition) {
+      await activeRendition.display(bookmark.cfi);
+    }
+    return;
+  }
+
+  const deleteId = target.getAttribute("data-delete-bookmark-id");
+  if (!deleteId) {
+    return;
+  }
+
+  const nextBookmarks = bookmarks.filter((entry) => entry.id !== deleteId);
+  await saveProgress(currentBookId, { bookmarks: nextBookmarks });
+  await renderBookmarksPanel(currentBookId);
+}
+
+function updateReadingProgress(cfi) {
+  if (!activeBook?.locations || !cfi) {
+    dom.readingProgress.textContent = "0%";
+    return;
+  }
+
+  const percentage = activeBook.locations.percentageFromCfi(cfi);
+  dom.readingProgress.textContent = computeLabelFromProgress(percentage);
+}
+
+function cleanupActiveReader() {
+  if (saveCfiTimer) {
+    window.clearTimeout(saveCfiTimer);
+    saveCfiTimer = null;
+  }
+
+  if (activeRendition) {
+    activeRendition.destroy();
+    activeRendition = null;
+  }
+
+  if (activeBook) {
+    activeBook.destroy();
+    activeBook = null;
+  }
+}
+
+async function renderBook(book, cfiFromRoute, token) {
+  cleanupActiveReader();
+  dom.readerContainer.textContent = "";
+
+  const bookInstance = ePub(book.fileData);
+  const rendition = bookInstance.renderTo("reader-container", {
+    width: "100%",
+    height: "70vh",
+    flow: "scrolled-doc",
+    manager: "continuous",
+  });
+
+  activeBook = bookInstance;
+  activeRendition = rendition;
+
+  rendition.themes.default({
+    body: {
+      background: "#050505",
+      color: "#efefef",
+      "font-family": "Courier New, monospace",
+      "line-height": "1.6",
+      margin: "0 auto",
+      "max-width": "760px",
+      padding: "24px 20px 60px",
+    },
+    a: {
+      color: "#cfd8dc",
+    },
+  });
+
+  await bookInstance.ready;
+  if (token !== routeToken || book.id !== currentBookId) {
+    return;
+  }
+
+  await bookInstance.locations.generate(1600);
+  if (token !== routeToken || book.id !== currentBookId) {
+    return;
+  }
+
+  const progress = await getProgressByBookId(book.id);
+  const savedCfi = progress?.cfi ?? "";
+  const startCfi = cfiFromRoute || savedCfi;
+
+  if (startCfi) {
+    try {
+      await rendition.display(startCfi);
+    } catch {
+      await rendition.display();
+    }
+  } else {
+    await rendition.display();
+  }
+
+  rendition.on("relocated", async (location) => {
+    if (book.id !== currentBookId) {
+      return;
+    }
+
+    const cfi = location?.start?.cfi;
+    if (!cfi) {
+      return;
+    }
+
+    updateReadingProgress(cfi);
+    debounceSaveCfi(book.id, cfi);
+  });
+
+  const currentLocation = rendition.currentLocation();
+  updateReadingProgress(currentLocation?.start?.cfi);
+  await renderBookmarksPanel(book.id);
 }
 
 function renderBookList(books, progressByBookId) {
@@ -300,17 +554,34 @@ function bindLibraryActions() {
   dom.openLibraryButton.addEventListener("click", () => {
     setHash(null);
   });
+
+  dom.addBookmarkButton.addEventListener("click", async () => {
+    await addBookmarkForCurrentBook();
+  });
+
+  dom.showBookmarksButton.addEventListener("click", async () => {
+    dom.bookmarksPanel.hidden = !dom.bookmarksPanel.hidden;
+    if (!dom.bookmarksPanel.hidden && currentBookId) {
+      await renderBookmarksPanel(currentBookId);
+    }
+  });
+
+  dom.bookmarkList.addEventListener("click", async (event) => {
+    await onBookmarkListClick(event);
+  });
 }
 
 async function applyRoute() {
   const nextToken = routeToken + 1;
   routeToken = nextToken;
-  const { bookId } = parseHash();
+  const { bookId, cfi } = parseHash();
 
   if (!bookId) {
+    cleanupActiveReader();
     currentBookId = null;
     dom.readerOverlay.hidden = false;
     dom.readerView.hidden = true;
+    dom.bookmarksPanel.hidden = true;
     return;
   }
 
@@ -327,14 +598,9 @@ async function applyRoute() {
   currentBookId = book.id;
   dom.readerOverlay.hidden = true;
   dom.readerView.hidden = false;
-  dom.readingProgress.textContent = "0%";
+  dom.bookmarksPanel.hidden = true;
 
-  const progress = await getProgressByBookId(book.id);
-  if (routeToken !== nextToken) {
-    return;
-  }
-
-  renderOpenBookPlaceholder(book, progress);
+  await renderBook(book, cfi, nextToken);
 }
 
 async function bootstrap() {

--- a/rs/site/static/reader.js
+++ b/rs/site/static/reader.js
@@ -1,0 +1,359 @@
+const DB_NAME = "epub-reader";
+const DB_VERSION = 1;
+const BOOKS_STORE = "books";
+const PROGRESS_STORE = "progress";
+
+let db = null;
+let currentBookId = null;
+let routeToken = 0;
+
+const dom = {
+  fileInput: document.querySelector("#epub-file-input"),
+  bookList: document.querySelector("#book-list"),
+  readerOverlay: document.querySelector("#reader-overlay"),
+  readerView: document.querySelector("#reader-view"),
+  readerContainer: document.querySelector("#reader-container"),
+  openLibraryButton: document.querySelector("#open-library"),
+  addBookmarkButton: document.querySelector("#add-bookmark"),
+  showBookmarksButton: document.querySelector("#show-bookmarks"),
+  readingProgress: document.querySelector("#reading-progress"),
+};
+
+function openDatabase() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => reject(new Error("IndexedDB upgrade blocked by another tab."));
+    request.onupgradeneeded = () => {
+      const upgradeDb = request.result;
+
+      if (!upgradeDb.objectStoreNames.contains(BOOKS_STORE)) {
+        upgradeDb.createObjectStore(BOOKS_STORE, {
+          keyPath: "id",
+          autoIncrement: true,
+        });
+      }
+
+      if (!upgradeDb.objectStoreNames.contains(PROGRESS_STORE)) {
+        upgradeDb.createObjectStore(PROGRESS_STORE, {
+          keyPath: "bookId",
+        });
+      }
+    };
+    request.onsuccess = () => {
+      const openedDb = request.result;
+      openedDb.onversionchange = () => {
+        openedDb.close();
+      };
+      resolve(openedDb);
+    };
+  });
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function withStore(storeNames, mode, operation) {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(storeNames, mode);
+    const stores = Array.isArray(storeNames)
+      ? storeNames.map((name) => transaction.objectStore(name))
+      : transaction.objectStore(storeNames);
+
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error);
+
+    const result = operation(stores);
+    transaction.oncomplete = () => resolve(result);
+  });
+}
+
+function requestToPromise(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function listBooks() {
+  return withStore(BOOKS_STORE, "readonly", (store) => requestToPromise(store.getAll()));
+}
+
+async function getBookById(bookId) {
+  return withStore(BOOKS_STORE, "readonly", (store) => requestToPromise(store.get(bookId)));
+}
+
+async function saveBook(record) {
+  return withStore(BOOKS_STORE, "readwrite", (store) => requestToPromise(store.add(record)));
+}
+
+async function getProgressByBookId(bookId) {
+  return withStore(PROGRESS_STORE, "readonly", (store) => requestToPromise(store.get(bookId)));
+}
+
+async function deleteBookAndProgress(bookId) {
+  return withStore([BOOKS_STORE, PROGRESS_STORE], "readwrite", ([booksStore, progressStore]) => {
+    booksStore.delete(bookId);
+    progressStore.delete(bookId);
+  });
+}
+
+function encodeCfi(cfi) {
+  return encodeURIComponent(cfi);
+}
+
+function decodeCfi(cfi) {
+  try {
+    return decodeURIComponent(cfi);
+  } catch {
+    return "";
+  }
+}
+
+function parseHash() {
+  const value = window.location.hash.replace(/^#/, "").trim();
+
+  if (!value) {
+    return { bookId: null, cfi: "" };
+  }
+
+  const [idPart, cfiPart] = value.split("/cfi=");
+  const parsedId = Number.parseInt(idPart, 10);
+
+  if (!Number.isInteger(parsedId) || parsedId <= 0) {
+    return { bookId: null, cfi: "" };
+  }
+
+  return {
+    bookId: parsedId,
+    cfi: cfiPart ? decodeCfi(cfiPart) : "",
+  };
+}
+
+function setHash(bookId, cfi = "") {
+  if (!bookId) {
+    window.location.hash = "";
+    return;
+  }
+
+  if (cfi) {
+    window.location.hash = `#${bookId}/cfi=${encodeCfi(cfi)}`;
+    return;
+  }
+
+  window.location.hash = `#${bookId}`;
+}
+
+function disableFutureControlsUntilRender() {
+  dom.addBookmarkButton.disabled = true;
+  dom.showBookmarksButton.disabled = true;
+}
+
+function showError(message) {
+  dom.readerContainer.textContent = "";
+  const errorNode = document.createElement("p");
+  errorNode.className = "reader-error";
+  errorNode.textContent = message;
+  dom.readerContainer.append(errorNode);
+}
+
+function renderOpenBookPlaceholder(book, progress) {
+  const progressLabel = progress?.cfi
+    ? "Saved reading position is available."
+    : "No saved reading position yet.";
+
+  dom.readerContainer.innerHTML = `
+    <div class="reader-placeholder">
+      <h2>${escapeHtml(book.title)}</h2>
+      <p><small>${escapeHtml(book.author)}</small></p>
+      <p>Reader engine initializes in the next commit. This confirms routing and storage are working.</p>
+      <p>${progressLabel}</p>
+    </div>
+  `;
+}
+
+function renderBookList(books, progressByBookId) {
+  if (!books.length) {
+    dom.bookList.innerHTML = "<li class=\"empty\">No books yet. Import one to begin.</li>";
+    return;
+  }
+
+  const items = books
+    .map((book) => {
+      const progress = progressByBookId.get(book.id);
+      const progressText = progress?.cfi ? "resume available" : "new";
+
+      return `
+        <li class="book-item" data-book-id="${book.id}">
+          <button class="button open-book" data-open-book-id="${book.id}">Open</button>
+          <button class="button delete-book" data-delete-book-id="${book.id}">Delete</button>
+          <span class="book-title">${escapeHtml(book.title)}</span>
+          <span class="book-meta">${escapeHtml(book.author)} - ${progressText}</span>
+        </li>
+      `;
+    })
+    .join("");
+
+  dom.bookList.innerHTML = items;
+}
+
+async function refreshLibrary() {
+  const books = await listBooks();
+  const progressByBookId = new Map();
+
+  await Promise.all(
+    books.map(async (book) => {
+      const progress = await getProgressByBookId(book.id);
+      progressByBookId.set(book.id, progress);
+    }),
+  );
+
+  renderBookList(books, progressByBookId);
+}
+
+async function onBookDelete(bookId) {
+  await deleteBookAndProgress(bookId);
+
+  if (currentBookId === bookId) {
+    currentBookId = null;
+    setHash(null);
+  }
+
+  await refreshLibrary();
+}
+
+async function onBookImport(files) {
+  const supportedFiles = [...files].filter(
+    (file) => file.name.toLowerCase().endsWith(".epub") || file.type === "application/epub+zip",
+  );
+
+  if (!supportedFiles.length) {
+    showError("No valid EPUB files selected.");
+    return;
+  }
+
+  for (const file of supportedFiles) {
+    const data = await file.arrayBuffer();
+    if (data.byteLength === 0) {
+      continue;
+    }
+
+    const fallbackTitle = file.name.replace(/\.epub$/iu, "") || "Untitled";
+    await saveBook({
+      title: fallbackTitle,
+      author: "Unknown author",
+      fileName: file.name,
+      fileData: data,
+      createdAt: Date.now(),
+    });
+  }
+
+  dom.fileInput.value = "";
+  await refreshLibrary();
+}
+
+function bindLibraryActions() {
+  dom.fileInput.addEventListener("change", async (event) => {
+    const files = event.target.files;
+    if (!files || !files.length) {
+      return;
+    }
+
+    try {
+      await onBookImport(files);
+    } catch {
+      showError("Failed to import book(s). Please try again.");
+    }
+  });
+
+  dom.bookList.addEventListener("click", async (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    const openId = target.getAttribute("data-open-book-id");
+    if (openId) {
+      setHash(Number.parseInt(openId, 10));
+      return;
+    }
+
+    const deleteId = target.getAttribute("data-delete-book-id");
+    if (!deleteId) {
+      return;
+    }
+
+    try {
+      await onBookDelete(Number.parseInt(deleteId, 10));
+    } catch {
+      showError("Failed to delete book.");
+    }
+  });
+
+  dom.openLibraryButton.addEventListener("click", () => {
+    setHash(null);
+  });
+}
+
+async function applyRoute() {
+  const nextToken = routeToken + 1;
+  routeToken = nextToken;
+  const { bookId } = parseHash();
+
+  if (!bookId) {
+    currentBookId = null;
+    dom.readerOverlay.hidden = false;
+    dom.readerView.hidden = true;
+    return;
+  }
+
+  const book = await getBookById(bookId);
+  if (routeToken !== nextToken) {
+    return;
+  }
+
+  if (!book) {
+    setHash(null);
+    return;
+  }
+
+  currentBookId = book.id;
+  dom.readerOverlay.hidden = true;
+  dom.readerView.hidden = false;
+  dom.readingProgress.textContent = "0%";
+
+  const progress = await getProgressByBookId(book.id);
+  if (routeToken !== nextToken) {
+    return;
+  }
+
+  renderOpenBookPlaceholder(book, progress);
+}
+
+async function bootstrap() {
+  disableFutureControlsUntilRender();
+
+  try {
+    db = await openDatabase();
+  } catch {
+    showError("Unable to open browser storage. Check privacy settings and retry.");
+    return;
+  }
+
+  bindLibraryActions();
+  await refreshLibrary();
+  await applyRoute();
+
+  window.addEventListener("hashchange", async () => {
+    await applyRoute();
+  });
+}
+
+void bootstrap();

--- a/rs/site/templates/index.html
+++ b/rs/site/templates/index.html
@@ -3,6 +3,8 @@
   <h1>rafiq's weblog</h1>
   <p>hi! i'm rafiq (@rrvsh on various platforms), and i'm a 25 year old software engineer. i've been tinkering and coding since I was 14, and plan to never stop. this website showcases some of my work, though you can find the rest on <a href="https://github.com/rrvsh">GitHub</a>.</p>
   <h2>my work</h2>
+  <h3>tools</h3>
+  <p><a href="/reader">epub reader</a> - a browser-local reader with progress and bookmarks.</p>
   <h3>prose</h3>
   <p>a collection of my writing, sorted by month.</p>
   {% for month in months %}

--- a/rs/site/templates/reader.html
+++ b/rs/site/templates/reader.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block content %}
+<link href="/static/reader.css" rel="stylesheet" />
+<script defer src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/epubjs@0.3.93/dist/epub.min.js"></script>
+<script defer src="/static/reader.js"></script>
+
+<div class="content reader-page">
+  <h1>epub reader</h1>
+  <p>store epubs in your browser and keep reading progress and bookmarks locally.</p>
+
+  <div id="reader-app" class="reader-app">
+    <div id="reader-overlay" class="reader-overlay">
+      <h2>library</h2>
+      <p>import one or more <code>.epub</code> files to get started.</p>
+      <input id="epub-file-input" type="file" accept=".epub,application/epub+zip" multiple>
+      <ul id="book-list" class="book-list"></ul>
+    </div>
+
+    <div id="reader-view" class="reader-view" hidden>
+      <div id="reader-controls" class="reader-controls">
+        <button id="open-library" class="button">Library</button>
+        <button id="add-bookmark" class="button">Add bookmark</button>
+        <button id="show-bookmarks" class="button">Bookmarks</button>
+        <span id="reading-progress" class="reading-progress">0%</span>
+      </div>
+      <div id="bookmarks-panel" class="bookmarks-panel" hidden>
+        <h3>bookmarks</h3>
+        <ul id="bookmark-list" class="bookmark-list"></ul>
+      </div>
+      <div id="reader-container" class="reader-container"></div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a new public `/reader` route and Askama template shell served by the site app
- implement a single-page EPUB reader using IndexedDB browser storage, hash routing, epub.js continuous scroll rendering, per-book progress, and bookmarks
- link the reader from the homepage and add reader-specific styling aligned with the current site theme

## Validation
- `just check-rs`