### PR TITLE
feat(site): add footer source link and commit hash

### DIFF
--- a/rs/site/src/app/controllers/article.rs
+++ b/rs/site/src/app/controllers/article.rs
@@ -1,5 +1,5 @@
 use crate::app::state::AppState;
-use crate::app::views::format_article_date;
+use crate::app::views::{base_template_github_url, current_commit_hash, format_article_date};
 use askama::Template;
 use axum::{
     extract::{Path, State},
@@ -16,6 +16,8 @@ struct ArticleTemplate {
     title: String,
     date: String,
     content: String,
+    base_template_url: String,
+    commit_hash: String,
 }
 
 pub async fn get(
@@ -31,6 +33,8 @@ pub async fn get(
         title: document.title.clone(),
         date: format_article_date(requested_date),
         content: to_html(&document.content),
+        base_template_url: base_template_github_url(),
+        commit_hash: current_commit_hash(),
     }
     .render()
     .map_or_else(

--- a/rs/site/src/app/controllers/index.rs
+++ b/rs/site/src/app/controllers/index.rs
@@ -1,5 +1,5 @@
 use crate::app::state::AppState;
-use crate::app::views::MonthGroup;
+use crate::app::views::{MonthGroup, base_template_github_url, current_commit_hash};
 use askama::Template;
 use axum::{
     extract::State,
@@ -12,11 +12,15 @@ use std::sync::Arc;
 #[template(path = "index.html")]
 struct IndexTemplate {
     months: Vec<MonthGroup>,
+    base_template_url: String,
+    commit_hash: String,
 }
 
 pub async fn get(State(state): State<Arc<AppState>>) -> Result<Response, StatusCode> {
     IndexTemplate {
         months: state.months.clone(),
+        base_template_url: base_template_github_url(),
+        commit_hash: current_commit_hash(),
     }
     .render()
     .map_or_else(

--- a/rs/site/src/app/controllers/reader.rs
+++ b/rs/site/src/app/controllers/reader.rs
@@ -1,3 +1,4 @@
+use crate::app::views::{base_template_github_url, current_commit_hash};
 use askama::Template;
 use axum::{
     http::StatusCode,
@@ -6,10 +7,18 @@ use axum::{
 
 #[derive(Template)]
 #[template(path = "reader.html")]
-struct ReaderTemplate {}
+struct ReaderTemplate {
+    base_template_url: String,
+    commit_hash: String,
+}
 
 pub async fn get() -> Result<Response, StatusCode> {
-    ReaderTemplate {}.render().map_or_else(
+    ReaderTemplate {
+        base_template_url: base_template_github_url(),
+        commit_hash: current_commit_hash(),
+    }
+    .render()
+    .map_or_else(
         |_| Err(StatusCode::INTERNAL_SERVER_ERROR),
         |rendered| Ok(Html(rendered).into_response()),
     )

--- a/rs/site/src/app/views/mod.rs
+++ b/rs/site/src/app/views/mod.rs
@@ -1,5 +1,10 @@
 use crate::app::models::document::Document;
 use chrono::{Datelike, NaiveDate};
+use std::process::Command;
+
+const BASE_TEMPLATE_PATH: &str = "rs/site/templates/base.html";
+const GITHUB_BLOB_PREFIX: &str = "https://github.com/rrvsh/tools/blob/prime";
+const UNKNOWN_COMMIT_HASH: &str = "unknown";
 
 #[derive(Clone)]
 pub struct ArticleLink {
@@ -62,4 +67,52 @@ pub fn format_article_date(date: NaiveDate) -> String {
         date.format("%B"),
         date.year()
     )
+}
+
+pub fn base_template_github_url() -> String {
+    format!("{GITHUB_BLOB_PREFIX}/{BASE_TEMPLATE_PATH}")
+}
+
+pub fn shorten_commit_hash(raw_hash: &str) -> String {
+    raw_hash.trim().chars().take(7).collect()
+}
+
+pub fn current_commit_hash() -> String {
+    std::env::var("GIT_COMMIT_HASH")
+        .or_else(|_| std::env::var("GITHUB_SHA"))
+        .ok()
+        .map(|sha| shorten_commit_hash(&sha))
+        .filter(|sha| !sha.is_empty())
+        .or_else(read_git_short_commit_hash)
+        .unwrap_or_else(|| UNKNOWN_COMMIT_HASH.to_string())
+}
+
+fn read_git_short_commit_hash() -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).to_string())
+        .map(|hash| shorten_commit_hash(&hash))
+        .filter(|hash| !hash.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{base_template_github_url, shorten_commit_hash};
+
+    #[test]
+    fn base_template_github_url_uses_prime_branch_prefix() {
+        let url = base_template_github_url();
+        assert_eq!(
+            url,
+            "https://github.com/rrvsh/tools/blob/prime/rs/site/templates/base.html"
+        );
+    }
+
+    #[test]
+    fn shorten_commit_hash_trims_and_limits_to_seven_characters() {
+        assert_eq!(shorten_commit_hash("  abcdef123456\n"), "abcdef1");
+    }
 }

--- a/rs/site/static/scripts.js
+++ b/rs/site/static/scripts.js
@@ -12,3 +12,11 @@ if (window.location.pathname ===  "/") {
 backToHomeButton.addEventListener("click", () => {
   window.location.href = "/";
 });
+
+const pageBottomSentinel = document.querySelector("#page-bottom-sentinel");
+if (pageBottomSentinel) {
+  const observer = new IntersectionObserver(([entry]) => {
+    document.body.classList.toggle("is-at-page-bottom", entry.isIntersecting);
+  });
+  observer.observe(pageBottomSentinel);
+}

--- a/rs/site/static/styles.css
+++ b/rs/site/static/styles.css
@@ -47,3 +47,21 @@ a:visited, a:hover {
   gap: 10px;
   justify-content: center;
 }
+
+.template-meta-footer {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  margin-top: 12px;
+  padding-bottom: 16px;
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  transition: opacity 140ms ease;
+}
+
+body.is-at-page-bottom .template-meta-footer {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}

--- a/rs/site/templates/base.html
+++ b/rs/site/templates/base.html
@@ -16,5 +16,10 @@
       <button id="back-to-top" class="button">Back to top</button>
       <button id="back-to-home" class="button">Back to home</button>
     </div>
+    <footer id="template-meta-footer" class="template-meta-footer">
+      <a href="{{ base_template_url }}" target="_blank" rel="noopener noreferrer">Template source</a>
+      <span>commit: {{ commit_hash }}</span>
+    </footer>
+    <div id="page-bottom-sentinel" aria-hidden="true"></div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add footer metadata to the shared base template with a link to `rs/site/templates/base.html` on `https://github.com/rrvsh/tools/blob/prime/...`
- compute and display a short commit hash in the footer for all page templates via shared view helpers
- reveal footer metadata only when the page-bottom sentinel is in view using `IntersectionObserver`

## Testing
- just check-rs
- just test-rs