### PR TITLE
feat(nemesis): auto shutdown at midnight if idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ these are the tools i currently use :3
 - `__curPos.file` will give the full evaluated path of the nix file it is called in. See [this issue](https://github.com/NixOS/nix/issues/5897#issuecomment-1012165198) for more information.
 - to get home-manager logs on darwin, use `darwin-rebuild` instead of `nh`
 
+## nemesis midnight shutdown
+
+- hypridle writes `idle`/`active` state to `/run/user/<uid>/hypridle-state` on nemesis.
+- idle timeout is `60` seconds.
+- `daily-midnight-poweroff` runs at `00:00` local time daily.
+- at `00:00`, if state is not `idle`, service exits immediately.
+- if state is `idle`, service sends a desktop notification that shutdown will happen in 1 minute.
+- service waits 60 seconds, checks state again, and powers off immediately if still `idle`.
+- service logs each step to journald (view with `journalctl -u daily-midnight-poweroff.service`).
+
 ### to kill Hyprland from an SSH session
 
 pkill .Hyprland-wrapp

--- a/nix/hosts/nemesis.nix
+++ b/nix/hosts/nemesis.nix
@@ -18,6 +18,11 @@ in
           modulesPath,
           ...
         }:
+        let
+          uid = toString config.users.users.rafiq.uid;
+          runtimeDir = "/run/user/${uid}";
+          idleStateFile = "${runtimeDir}/hypridle-state";
+        in
         {
           imports = [
             inputs.sops-nix.nixosModules.sops
@@ -92,6 +97,54 @@ in
               jack.enable = true;
               wireplumber.enable = true;
             };
+          };
+          systemd.services.daily-midnight-poweroff = {
+            description = "Power off nemesis daily at midnight";
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = pkgs.writeShellScript "daily-midnight-poweroff" ''
+                set -euo pipefail
+
+                log() {
+                  printf '%s %s\n' "$(date '+%F %T %Z')" "$1"
+                }
+                read_state() {
+                  if [ -r "$state_file" ]; then
+                    ${pkgs.coreutils}/bin/cat "$state_file" || true
+                    return
+                  fi
+                  printf 'unknown'
+                }
+                state_file="${idleStateFile}"
+                runtime_dir="${runtimeDir}"
+
+                state="$(read_state)"
+                log "midnight check state=$state file=$state_file"
+                if [ "$state" != "idle" ]; then
+                  log "not idle at 00:00, exiting"
+                  exit 0
+                fi
+
+                ${pkgs.util-linux}/bin/runuser -u rafiq -- env \
+                  XDG_RUNTIME_DIR="$runtime_dir" \
+                  DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus" \
+                  ${pkgs.libnotify}/bin/notify-send \
+                  "Midnight auto-shutdown" \
+                  "Idle detected. Shutting down in 1 minute unless activity resumes." \
+                  || true
+                log "idle at 00:00, notification sent, waiting 60s"
+                ${pkgs.coreutils}/bin/sleep 60
+
+                state_after="$(read_state)"
+                log "post-wait check state=$state_after file=$state_file"
+                if [ "$state_after" = "idle" ]; then
+                  log "still idle at 00:01, powering off now"
+                  ${pkgs.systemd}/bin/systemctl poweroff
+                fi
+                log "activity resumed before 00:01, skipping shutdown"
+              '';
+            };
+            startAt = "*-*-* 00:00:00";
           };
           sops.secrets."tailscale/authkey" = {
             sopsFile = cfg.paths.root + "/sops/tailscale.yaml";

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -216,11 +216,31 @@ let
         };
       };
       services.dunst.enable = pkgs.stdenv.isLinux;
+      services.hypridle = lib.mkIf (pkgs.stdenv.isLinux && (osConfig.programs.hyprland.enable or false)) (
+        let
+          uid = toString osConfig.users.users.rafiq.uid;
+          runtimeDir = "/run/user/${uid}";
+          idleStateFile = "${runtimeDir}/hypridle-state";
+        in
+        {
+          enable = true;
+          settings = {
+            listener = [
+              {
+                timeout = 60;
+                on-timeout = "${pkgs.bash}/bin/bash -lc 'printf idle > \"${idleStateFile}\"'";
+                on-resume = "${pkgs.bash}/bin/bash -lc 'printf active > \"${idleStateFile}\"'";
+              }
+            ];
+          };
+        }
+      );
       home.packages =
         (lib.lists.optional pkgs.stdenv.isDarwin pkgs.firefox-bin)
         ++ (lib.lists.optional pkgs.stdenv.isDarwin pkgs.alt-tab-macos)
         ++ (lib.lists.optional pkgs.stdenv.isDarwin pkgs.monitorcontrol)
         ++ (lib.lists.optional pkgs.stdenv.isLinux pkgs.mixxx)
+        ++ (lib.lists.optional pkgs.stdenv.isLinux pkgs.libnotify)
         ++ [
           pkgs.gh
           pkgs.ddgr


### PR DESCRIPTION
## Summary
- add `daily-midnight-poweroff` systemd service on nemesis that runs at `00:00`, exits early unless hypridle state is idle, sends a 1-minute warning notification, then re-checks and powers off if still idle
- configure hypridle to write deterministic idle state (`idle`/`active`) to `/run/user/<uid>/hypridle-state` with a 60-second timeout, and install `libnotify` for notification delivery
- document the full midnight shutdown behavior and log inspection command in `README.md`

## Verification
- ran `just format-nix`
- ran `just lint-nix`
- ran `just check-nix`