### PR TITLE
feat(site): automate production deploy workflow

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,0 +1,93 @@
+name: Deploy site to production
+
+on:
+  push:
+    branches: [prime]
+    paths:
+      - "rs/**"
+      - "nix/packages/site.nix"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/deploy-site.yaml"
+  repository_dispatch:
+    types: [site-content-updated]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-site-production
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        timeout-minutes: 5
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        timeout-minutes: 5
+        uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Nix dependencies
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+
+      - name: Refresh site-content input
+        run: nix flake lock --update-input site-content
+
+      - name: Build deploy bundle
+        run: nix build .#packages.x86_64-linux.site-deploy
+
+      - name: Prepare SSH key and known hosts
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_KNOWN_HOSTS: ${{ secrets.VPS_KNOWN_HOSTS }}
+        run: |
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$VPS_SSH_KEY" > "$HOME/.ssh/id_ed25519"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$VPS_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          chmod 644 "$HOME/.ssh/known_hosts"
+
+      - name: Upload release to VPS
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_PORT: ${{ secrets.VPS_PORT }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          VPS_PORT="${VPS_PORT:-22}"
+          REMOTE_RELEASE_DIR="/opt/site/releases/${RELEASE_SHA}"
+          ssh -p "${VPS_PORT}" "${VPS_USER}@${VPS_HOST}" "mkdir -p '${REMOTE_RELEASE_DIR}'"
+          rsync -az --delete \
+            -e "ssh -p ${VPS_PORT}" \
+            result/ "${VPS_USER}@${VPS_HOST}:${REMOTE_RELEASE_DIR}/"
+
+      - name: Activate release and restart service
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_PORT: ${{ secrets.VPS_PORT }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          VPS_PORT="${VPS_PORT:-22}"
+          ssh -p "${VPS_PORT}" "${VPS_USER}@${VPS_HOST}" "
+            set -euo pipefail
+            RELEASE_DIR='/opt/site/releases/${RELEASE_SHA}'
+            ln -sfn \"\$RELEASE_DIR\" /opt/site/current
+            sudo /bin/systemctl restart site
+            sudo /bin/systemctl is-active site
+          "

--- a/README.md
+++ b/README.md
@@ -29,3 +29,162 @@ pkill .Hyprland-wrapp
 - [NotAShelf](https://github.com/notashelf/nyx) for introducing me to the idea of monorepos and custom logic (read: over-engineering) for Nix flakes
 - [drupol/infra](https://not-a-number.io/2025/refactoring-my-infrastructure-as-code-configurations/) for introducing the dendritic pattern to me, and [mightyiam](https://discourse.nixos.org/t/pattern-every-file-is-a-flake-parts-module/61271) for pioneering it.
 - [Cross-compiling to ARM64 in GitHub Actions](https://thewagner.net/blog/2023/11/20/building-nix-packages-for-the-raspberry-pi-with-github-actions)
+
+## production deployment automation (rrv.sh)
+
+this repository deploys `rs/site` to production at `rrv.sh` by shipping a fully baked artifact
+(binary + static assets + site-content) to `45.32.116.84`.
+
+### 1) create github environment
+
+1. open repository `rrvsh/tools` -> Settings -> Environments.
+2. create environment named `production`.
+3. add these environment secrets exactly:
+   - `VPS_HOST` = `45.32.116.84`
+   - `VPS_PORT` = `22`
+   - `VPS_USER` = deploy user on VPS (example: `deploy`)
+   - `VPS_SSH_KEY` = private key content for deploy key (full multiline key)
+   - `VPS_KNOWN_HOSTS` = output of `ssh-keyscan -H 45.32.116.84`
+4. optional: add required reviewers to gate production deploy runs.
+
+### 2) provision deploy user and paths on vps
+
+run these commands on the VPS as root:
+
+```bash
+useradd --create-home --shell /bin/bash deploy || true
+install -d -m 755 -o deploy -g deploy /opt/site
+install -d -m 755 -o deploy -g deploy /opt/site/releases
+```
+
+### 3) install deploy ssh key
+
+1. generate keypair locally:
+
+```bash
+ssh-keygen -t ed25519 -C github-actions-deploy -f ./deploy_rrv_site
+```
+
+2. add the public key to `/home/deploy/.ssh/authorized_keys` on VPS:
+
+```bash
+install -d -m 700 -o deploy -g deploy /home/deploy/.ssh
+cat ./deploy_rrv_site.pub >> /home/deploy/.ssh/authorized_keys
+chown deploy:deploy /home/deploy/.ssh/authorized_keys
+chmod 600 /home/deploy/.ssh/authorized_keys
+```
+
+3. put the private key (`./deploy_rrv_site`) into `production` secret `VPS_SSH_KEY`.
+
+### 4) configure systemd service to use current symlink
+
+create `/etc/systemd/system/site.service`:
+
+```ini
+[Unit]
+Description=rrv.sh site
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=deploy
+Group=deploy
+Environment=HOST=0.0.0.0
+Environment=PORT=8080
+Environment=SITE_CONTENT_DIR=/opt/site/current/content
+Environment=STATIC_DIR=/opt/site/current/static
+ExecStart=/opt/site/current/bin/site
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+```
+
+enable it:
+
+```bash
+systemctl daemon-reload
+systemctl enable --now site
+```
+
+### 5) allow minimal sudo for service restart
+
+create `/etc/sudoers.d/site-deploy`:
+
+```sudoers
+deploy ALL=(root) NOPASSWD: /bin/systemctl restart site, /bin/systemctl is-active site
+```
+
+validate:
+
+```bash
+visudo -cf /etc/sudoers.d/site-deploy
+```
+
+### 6) remove old cron-based deployment
+
+1. disable and remove cronjob that pulls `rrvsh/site-content` and static/app updates.
+2. ensure no remaining scripts overwrite `/opt/site/current`.
+3. keep old scripts for one rollback window only, then delete.
+
+### 7) add cross-repo dispatch from rrvsh/site-content
+
+in `rrvsh/site-content`, add a workflow that dispatches to `rrvsh/tools` on push to default branch.
+store a PAT in `rrvsh/site-content` secrets:
+- `TOOLS_REPO_DISPATCH_TOKEN` with permission to call repository dispatch on `rrvsh/tools`.
+
+workflow file for `rrvsh/site-content` should be:
+
+```yaml
+name: trigger tools deploy
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger repository dispatch in rrvsh/tools
+        env:
+          GH_TOKEN: ${{ secrets.TOOLS_REPO_DISPATCH_TOKEN }}
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/rrvsh/tools/dispatches \
+            -d '{"event_type":"site-content-updated"}'
+```
+
+### 8) first deploy and verification
+
+1. trigger deploy workflow manually (`workflow_dispatch`) in `rrvsh/tools`.
+2. verify on VPS:
+
+```bash
+systemctl status site --no-pager
+readlink -f /opt/site/current
+ls -la /opt/site/current
+```
+
+3. verify externally:
+   - `curl -I https://rrv.sh`
+   - open `https://rrv.sh` and confirm fresh content + static assets.
+
+### 9) rollback procedure
+
+to rollback to a previous release SHA:
+
+```bash
+ln -sfn /opt/site/releases/<previous_sha> /opt/site/current
+systemctl restart site
+systemctl is-active site
+```

--- a/nix/packages/site.nix
+++ b/nix/packages/site.nix
@@ -1,15 +1,38 @@
-{ config, ... }:
+{ config, inputs, ... }:
 let
   inherit (config.flake.paths) root;
 in
 {
   perSystem =
     { pkgs, ... }:
-    {
-      packages.site-bin = pkgs.rustPlatform.buildRustPackage {
+    let
+      siteBin = pkgs.rustPlatform.buildRustPackage {
         name = "site";
         src = root + /rs;
         cargoLock.lockFile = root + /rs/Cargo.lock;
+      };
+    in
+    {
+      packages.site-bin = siteBin;
+
+      packages.site-deploy = pkgs.stdenvNoCC.mkDerivation {
+        pname = "site-deploy";
+        version = "0.1.0";
+        dontUnpack = true;
+        nativeBuildInputs = [ pkgs.rsync ];
+        buildCommand = ''
+          mkdir -p "$out/bin" "$out/static" "$out/content"
+
+          install -m0755 "${siteBin}/bin/site" "$out/bin/site"
+
+          rsync -a --delete \
+            "${root}/rs/site/static/" \
+            "$out/static/"
+
+          rsync -a --delete \
+            "${inputs.site-content}/" \
+            "$out/content/"
+        '';
       };
     };
 }


### PR DESCRIPTION
## Summary
- add a production deploy workflow that builds a baked site artifact (binary + static + site-content), ships it to the VPS, and restarts the `site` service
- add a new Nix package output (`site-deploy`) to produce the deployable directory layout used by CI
- document all required manual setup and cross-repo dispatch steps in README so the rollout is explicit end-to-end

## Validation
- nix develop .#ci-all -c just check