### PR TITLE
feat(hm): add pi-coding-agent and remove opencode

### DIFF
--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -236,14 +236,16 @@ let
         }
       );
       home.packages =
-        (lib.lists.optional pkgs.stdenv.isDarwin pkgs.firefox-bin)
-        ++ (lib.lists.optional pkgs.stdenv.isDarwin pkgs.alt-tab-macos)
-        ++ (lib.lists.optional pkgs.stdenv.isDarwin pkgs.monitorcontrol)
-        ++ (lib.lists.optional pkgs.stdenv.isLinux pkgs.mixxx)
-        ++ (lib.lists.optional pkgs.stdenv.isLinux pkgs.libnotify)
+        with pkgs;
+        (lib.lists.optional stdenv.isDarwin firefox-bin)
+        ++ (lib.lists.optional stdenv.isDarwin alt-tab-macos)
+        ++ (lib.lists.optional stdenv.isDarwin monitorcontrol)
+        ++ (lib.lists.optional stdenv.isLinux mixxx)
+        ++ (lib.lists.optional stdenv.isLinux libnotify)
         ++ [
-          pkgs.gh
-          pkgs.ddgr
+          gh
+          ddgr
+          pi-coding-agent
         ];
       targets.darwin.copyApps.enable = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (lib.mkForce false);
       assertions = lib.optionals pkgs.stdenv.hostPlatform.isLinux [

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -144,7 +144,6 @@ let
             }
           ];
         };
-        opencode.enable = true;
         ghostty = {
           enable = true;
           package = if pkgs.stdenv.isDarwin then null else pkgs.ghostty;
@@ -283,7 +282,6 @@ let
         e = "fish -c 'set -e var; set var (sk); test -n \"$var\"; and $EDITOR $var'";
         lib = "fooc \"$HOME/0_library\"";
         t = config.programs.yazi.shellWrapperName;
-        oc = "opencode";
         search = "ddgr -n 5 -C -x --np";
       };
     };


### PR DESCRIPTION
## Summary
- add `pi-coding-agent` to Home Manager packages
- remove `opencode.enable` from Home Manager programs
- remove `oc` alias for opencode

## Commits
- feat(hm): add pi-coding-agent package
- chore(hm): remove opencode config and alias

## Validation
- just check
