### PR TITLE
feat(nemesis): add waybar with appear on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ Note: on this machine, unsetting from `boot.loader.systemd-boot.extraInstallComm
 - [NotAShelf](https://github.com/notashelf/nyx) for introducing me to the idea of monorepos and custom logic (read: over-engineering) for Nix flakes
 - [drupol/infra](https://not-a-number.io/2025/refactoring-my-infrastructure-as-code-configurations/) for introducing the dendritic pattern to me, and [mightyiam](https://discourse.nixos.org/t/pattern-every-file-is-a-flake-parts-module/61271) for pioneering it.
 - [Cross-compiling to ARM64 in GitHub Actions](https://thewagner.net/blog/2023/11/20/building-nix-packages-for-the-raspberry-pi-with-github-actions)
+- [waliori/waybar_peek](https://github.com/waliori/waybar_peek) for the Hyprland Waybar auto-hide approach (vendored in `scripts/waybar_peek.py` with small local env-config tweaks)

--- a/nix/hosts/nemesis.nix
+++ b/nix/hosts/nemesis.nix
@@ -223,6 +223,9 @@ in
             LIBVA_DRIVER_NAME = "nvidia";
             NIXOS_OZONE_WL = "1";
           };
+          fonts.packages = with pkgs; [
+            nerd-fonts.jetbrains-mono
+          ];
           programs = {
             hyprland = {
               enable = true;

--- a/nix/hosts/nemesis.nix
+++ b/nix/hosts/nemesis.nix
@@ -225,6 +225,8 @@ in
           };
           fonts.packages = with pkgs; [
             nerd-fonts.jetbrains-mono
+            nerd-fonts.gohufont
+            monocraft
           ];
           programs = {
             hyprland = {

--- a/nix/hosts/nemesis.nix
+++ b/nix/hosts/nemesis.nix
@@ -225,7 +225,6 @@ in
           };
           fonts.packages = with pkgs; [
             nerd-fonts.jetbrains-mono
-            nerd-fonts.gohufont
             monocraft
           ];
           programs = {

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -15,6 +15,10 @@ let
       xdg.configFile."nvim/lua".source = root + /nvim;
       programs = {
         wofi.enable = pkgs.stdenv.isLinux;
+        waybar = {
+          enable = true;
+          systemd.enable = true;
+        };
         fish = {
           enable = true;
           interactiveShellInit = ''

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -254,6 +254,11 @@ let
         configType = "lua";
         package = null;
         portalPackage = null;
+        extraConfig = ''
+          hl.on("hyprland.start", function()
+            hl.exec_cmd("systemctl --user import-environment WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_RUNTIME_DIR DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && ${pkgs.dbus}/bin/dbus-update-activation-environment --systemd WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_RUNTIME_DIR DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user restart waybar.service waybar-peek.service")
+          end)
+        '';
         settings = {
           monitor = [
             {
@@ -424,6 +429,9 @@ let
             }
           ];
         };
+      };
+      systemd.user.services.waybar = lib.mkIf pkgs.stdenv.isLinux {
+        Unit.ConditionEnvironment = lib.mkForce [ ];
       };
       systemd.user.services.waybar-peek =
         lib.mkIf (pkgs.stdenv.isLinux && (osConfig.programs.hyprland.enable or false))

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -24,13 +24,16 @@ let
             }
 
             #clock {
-              font-family: "JetBrainsMono Nerd Font", "JetBrains Mono";
               background: #000000;
               color: #ffffff;
               border: 1px solid #ffffff;
               border-radius: 9999px;
               padding: 3px 8px;
               margin: 4px 0;
+              font-family: "Monocraft";
+              font-size: 12px;
+              font-weight: 400;
+              font-style: normal;
             }
           '';
           settings = [

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -13,6 +13,10 @@ let
     {
       imports = [ inputs.nix-index-database.homeModules.nix-index ];
       xdg.configFile."nvim/lua".source = root + /nvim;
+      xdg.configFile."hypr/scripts/waybar_peek.py" = {
+        source = root + /scripts/waybar_peek.py;
+        executable = true;
+      };
       programs = {
         wofi.enable = pkgs.stdenv.isLinux;
         waybar = {
@@ -40,6 +44,10 @@ let
             {
               layer = "overlay";
               exclusive = false;
+              start_hidden = true;
+              ipc = true;
+              on-sigusr1 = "hide";
+              on-sigusr2 = "show";
               modules-left = [ ];
               modules-center = [ "clock" ];
               modules-right = [ ];
@@ -259,22 +267,6 @@ let
               ];
             }
             {
-              # Toggle Waybar by sending SIGUSR1 to the systemd user service.
-              # Waybar defaults SIGUSR1 to visibility toggle (on-sigusr1 = "toggle").
-              _args = [
-                "SUPER + SUPER_L"
-                (lib.generators.mkLuaInline "hl.dsp.exec_cmd(\"systemctl --user kill -s SIGUSR1 waybar.service\")")
-                { release = true; }
-              ];
-            }
-            {
-              _args = [
-                "SUPER + SUPER_R"
-                (lib.generators.mkLuaInline "hl.dsp.exec_cmd(\"systemctl --user kill -s SIGUSR1 waybar.service\")")
-                { release = true; }
-              ];
-            }
-            {
               _args = [
                 "ALT + CTRL + 1"
                 (lib.generators.mkLuaInline "hl.dsp.exec_cmd(\"ghostty\")")
@@ -387,6 +379,32 @@ let
           ];
         };
       };
+      systemd.user.services.waybar-peek =
+        lib.mkIf (pkgs.stdenv.isLinux && (osConfig.programs.hyprland.enable or false))
+          {
+            Unit = {
+              Description = "waybar_peek auto-hide helper for Hyprland";
+              After = [
+                "graphical-session.target"
+                "waybar.service"
+              ];
+              Wants = [
+                "graphical-session.target"
+                "waybar.service"
+              ];
+            };
+            Service = {
+              ExecStart = "${pkgs.python3}/bin/python3 ${config.xdg.configHome}/hypr/scripts/waybar_peek.py";
+              Restart = "always";
+              RestartSec = 1;
+              Environment = [
+                "WAYBAR_PEEK_SHOW_PX=5"
+                "WAYBAR_PEEK_HIDE_PX=50"
+                "WAYBAR_PEEK_POLL=0.1"
+              ];
+            };
+            Install.WantedBy = [ "default.target" ];
+          };
       services.dunst.enable = pkgs.stdenv.isLinux;
       services.hypridle = lib.mkIf (pkgs.stdenv.isLinux && (osConfig.programs.hyprland.enable or false)) (
         let

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -33,7 +33,7 @@ let
       };
       programs = {
         wofi.enable = pkgs.stdenv.isLinux;
-        waybar = {
+        waybar = lib.mkIf pkgs.stdenv.isLinux {
           enable = true;
           systemd.enable = true;
           style = ''

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -21,6 +21,8 @@ let
           style = "";
           settings = [
             {
+              layer = "overlay";
+              exclusive = false;
               modules-left = [ ];
               modules-center = [ ];
               modules-right = [ "clock" ];

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -240,6 +240,22 @@ let
               ];
             }
             {
+              # Toggle Waybar by sending SIGUSR1 to the systemd user service.
+              # Waybar defaults SIGUSR1 to visibility toggle (on-sigusr1 = "toggle").
+              _args = [
+                "SUPER + SUPER_L"
+                (lib.generators.mkLuaInline "hl.dsp.exec_cmd(\"systemctl --user kill -s SIGUSR1 waybar.service\")")
+                { release = true; }
+              ];
+            }
+            {
+              _args = [
+                "SUPER + SUPER_R"
+                (lib.generators.mkLuaInline "hl.dsp.exec_cmd(\"systemctl --user kill -s SIGUSR1 waybar.service\")")
+                { release = true; }
+              ];
+            }
+            {
               _args = [
                 "ALT + CTRL + 1"
                 (lib.generators.mkLuaInline "hl.dsp.exec_cmd(\"ghostty\")")

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -12,10 +12,24 @@ let
     }:
     {
       imports = [ inputs.nix-index-database.homeModules.nix-index ];
-      xdg.configFile."nvim/lua".source = root + /nvim;
-      xdg.configFile."hypr/scripts/waybar_peek.py" = {
-        source = root + /scripts/waybar_peek.py;
-        executable = true;
+      xdg.configFile = {
+        "nvim/lua".source = root + /nvim;
+        "hypr/scripts/waybar_peek.py" = {
+          source = root + /scripts/waybar_peek.py;
+          executable = true;
+        };
+        "waybar/power_menu.xml".text = ''
+          <?xml version="1.0" encoding="UTF-8"?>
+          <interface>
+            <object class="GtkMenu" id="menu">
+              <child>
+                <object class="GtkMenuItem" id="win11-reboot">
+                  <property name="label">Reboot to Windows 11</property>
+                </object>
+              </child>
+            </object>
+          </interface>
+        '';
       };
       programs = {
         wofi.enable = pkgs.stdenv.isLinux;
@@ -27,7 +41,8 @@ let
               background: transparent;
             }
 
-            #clock {
+            #clock,
+            #custom-power {
               background: #000000;
               color: #ffffff;
               border: 1px solid #ffffff;
@@ -38,6 +53,17 @@ let
               font-size: 12px;
               font-weight: 400;
               font-style: normal;
+            }
+
+            menu {
+              border-radius: 12px;
+              background: #000000;
+              color: #ffffff;
+              border: 1px solid #ffffff;
+            }
+
+            menuitem {
+              border-radius: 8px;
             }
           '';
           settings = [
@@ -50,10 +76,19 @@ let
               on-sigusr2 = "show";
               modules-left = [ ];
               modules-center = [ "clock" ];
-              modules-right = [ ];
+              modules-right = [ "custom/power" ];
               clock = {
                 format = "{:%H:%M}";
                 tooltip = false;
+              };
+              "custom/power" = {
+                format = "⏻";
+                tooltip = false;
+                menu = "on-click";
+                menu-file = "~/.config/waybar/power_menu.xml";
+                menu-actions = {
+                  "win11-reboot" = "notify-send 'Waybar' 'Placeholder: reboot to Windows 11'";
+                };
               };
             }
           ];
@@ -399,7 +434,7 @@ let
               RestartSec = 1;
               Environment = [
                 "WAYBAR_PEEK_SHOW_PX=5"
-                "WAYBAR_PEEK_HIDE_PX=50"
+                "WAYBAR_PEEK_HIDE_PX=120"
                 "WAYBAR_PEEK_POLL=0.1"
               ];
             };

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -60,10 +60,21 @@ let
               background: #000000;
               color: #ffffff;
               border: 1px solid #ffffff;
+              font-family: "Monocraft";
+              font-size: 12px;
+              font-weight: 400;
+              padding: 4px;
+              margin-top: 6px;
+              margin-left: 6px;
             }
 
             menuitem {
               border-radius: 8px;
+              font-family: "Monocraft";
+              font-size: 12px;
+              font-weight: 400;
+              margin: 2px;
+              padding: 4px 8px;
             }
           '';
           settings = [

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -18,6 +18,18 @@ let
         waybar = {
           enable = true;
           systemd.enable = true;
+          style = "";
+          settings = [
+            {
+              modules-left = [ ];
+              modules-center = [ ];
+              modules-right = [ "clock" ];
+              clock = {
+                format = "{:%H:%M}";
+                tooltip = false;
+              };
+            }
+          ];
         };
         fish = {
           enable = true;

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -98,7 +98,7 @@ let
                 menu = "on-click";
                 menu-file = "~/.config/waybar/power_menu.xml";
                 menu-actions = {
-                  "win11-reboot" = "notify-send 'Waybar' 'Placeholder: reboot to Windows 11'";
+                  "win11-reboot" = "sudo systemctl reboot --boot-loader-entry windows_11-pro.conf";
                 };
               };
             }

--- a/nix/rafiq.nix
+++ b/nix/rafiq.nix
@@ -18,14 +18,28 @@ let
         waybar = {
           enable = true;
           systemd.enable = true;
-          style = "";
+          style = ''
+            window#waybar {
+              background: transparent;
+            }
+
+            #clock {
+              font-family: "JetBrainsMono Nerd Font", "JetBrains Mono";
+              background: #000000;
+              color: #ffffff;
+              border: 1px solid #ffffff;
+              border-radius: 9999px;
+              padding: 3px 8px;
+              margin: 4px 0;
+            }
+          '';
           settings = [
             {
               layer = "overlay";
               exclusive = false;
               modules-left = [ ];
-              modules-center = [ ];
-              modules-right = [ "clock" ];
+              modules-center = [ "clock" ];
+              modules-right = [ ];
               clock = {
                 format = "{:%H:%M}";
                 tooltip = false;

--- a/scripts/waybar_peek.py
+++ b/scripts/waybar_peek.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Waybar Peek - Auto-hide for Hyprland (Multi-monitor)
+Shows waybar when cursor is at top edge, hides when workspace has windows.
+
+Toggle auto-hide: pkill -HUP -f waybar_peek
+"""
+
+import json
+import os
+import signal
+import socket
+import time
+from pathlib import Path
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except Exception:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except Exception:
+        return default
+
+
+# Configuration
+PIXEL_THRESHOLD = _env_int("WAYBAR_PEEK_SHOW_PX", 5)          # Show bar when within 5px of top
+PIXEL_THRESHOLD_HIDE = _env_int("WAYBAR_PEEK_HIDE_PX", 50)    # Hide when cursor goes below 50px
+POLL_INTERVAL = _env_float("WAYBAR_PEEK_POLL", 0.1)          # Poll every 100ms
+
+class WaybarPeek:
+    def __init__(self):
+        self.xdg_runtime = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        self.hypr_sig = os.environ.get("HYPRLAND_INSTANCE_SIGNATURE", "")
+        self.socket_path = f"{self.xdg_runtime}/hypr/{self.hypr_sig}/.socket.sock"
+
+        self.cursor_at_top = False
+        self.last_visibility = None
+        self.waybar_pid = None
+        self.enabled = True  # Auto-hide enabled by default
+
+        # Setup signal handler for toggle
+        signal.signal(signal.SIGHUP, self.toggle_handler)
+
+    def toggle_handler(self, signum, frame):
+        """Handle SIGHUP to toggle auto-hide on/off"""
+        self.enabled = not self.enabled
+        status = "enabled" if self.enabled else "disabled"
+        print(f"Auto-hide {status}")
+
+        if not self.enabled:
+            # When disabled, always show the bar
+            self.set_waybar_visible(True)
+            self.last_visibility = True
+        else:
+            # When re-enabled, force state recalculation
+            self.last_visibility = None
+
+    def hypr_query(self, cmd: str) -> str:
+        """Query Hyprland via socket"""
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.connect(self.socket_path)
+            sock.send(cmd.encode())
+            response = b""
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                response += chunk
+            sock.close()
+            return response.decode()
+        except Exception:
+            return ""
+
+    def get_cursor_pos(self) -> tuple:
+        """Get cursor position as (x, y)"""
+        try:
+            data = json.loads(self.hypr_query("j/cursorpos"))
+            return (data.get("x", 0), data.get("y", 0))
+        except Exception:
+            return (0, 0)
+
+    def get_monitors(self) -> list:
+        """Get all monitors with their bounds"""
+        try:
+            return json.loads(self.hypr_query("j/monitors"))
+        except Exception:
+            return []
+
+    def check_windows(self) -> bool:
+        """Check if active workspace has windows"""
+        try:
+            data = json.loads(self.hypr_query("j/activeworkspace"))
+            return data.get("windows", 0) > 0
+        except Exception:
+            return False
+
+    def find_waybar_pid(self) -> int:
+        """Find waybar process ID"""
+        try:
+            for entry in Path("/proc").iterdir():
+                if not entry.is_dir() or not entry.name.isdigit():
+                    continue
+                comm_file = entry / "comm"
+                if comm_file.exists():
+                    comm = comm_file.read_text().strip()
+                    if comm in ("waybar", ".waybar-wrapped"):
+                        return int(entry.name)
+        except Exception:
+            pass
+        return None
+
+    def set_waybar_visible(self, visible: bool) -> bool:
+        """Send signal to waybar to show/hide"""
+        if self.waybar_pid is None:
+            self.waybar_pid = self.find_waybar_pid()
+
+        if self.waybar_pid is None:
+            return False
+
+        try:
+            sig = signal.SIGUSR2 if visible else signal.SIGUSR1
+            os.kill(self.waybar_pid, sig)
+            return True
+        except ProcessLookupError:
+            self.waybar_pid = self.find_waybar_pid()
+            if self.waybar_pid:
+                try:
+                    sig = signal.SIGUSR2 if visible else signal.SIGUSR1
+                    os.kill(self.waybar_pid, sig)
+                    return True
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        return False
+
+    def is_cursor_at_top(self) -> bool:
+        """Check if cursor is at top edge of any monitor"""
+        cursor_x, cursor_y = self.get_cursor_pos()
+        monitors = self.get_monitors()
+
+        for m in monitors:
+            mx, my = m.get("x", 0), m.get("y", 0)
+            mw, mh = m.get("width", 0), m.get("height", 0)
+
+            # Check if cursor is on this monitor
+            if mx <= cursor_x <= mx + mw and my <= cursor_y <= my + mh:
+                # Calculate local Y position relative to this monitor
+                local_y = cursor_y - my
+
+                # Use different thresholds based on current state
+                threshold = PIXEL_THRESHOLD_HIDE if self.cursor_at_top else PIXEL_THRESHOLD
+                return local_y <= threshold
+
+        return False
+
+    def run(self):
+        """Main loop"""
+        print(f"waybar-peek started (PID: {os.getpid()})")
+        print(f"Socket: {self.socket_path}")
+        print(f"Toggle auto-hide: pkill -HUP -f waybar_peek")
+
+        # Initial state
+        windows_opened = self.check_windows()
+        self.last_visibility = not windows_opened
+
+        while True:
+            try:
+                # Skip auto-hide logic if disabled
+                if not self.enabled:
+                    time.sleep(POLL_INTERVAL)
+                    continue
+
+                # Check cursor position
+                new_cursor_at_top = self.is_cursor_at_top()
+                if new_cursor_at_top != self.cursor_at_top:
+                    self.cursor_at_top = new_cursor_at_top
+
+                # Check windows
+                windows_opened = self.check_windows()
+
+                # Determine visibility: show if cursor at top OR no windows
+                should_be_visible = self.cursor_at_top or not windows_opened
+
+                # Update waybar if state changed
+                if should_be_visible != self.last_visibility:
+                    self.set_waybar_visible(should_be_visible)
+                    self.last_visibility = should_be_visible
+
+                time.sleep(POLL_INTERVAL)
+
+            except KeyboardInterrupt:
+                print("\nExiting...")
+                break
+            except Exception as e:
+                print(f"Error: {e}")
+                time.sleep(1)
+
+if __name__ == "__main__":
+    app = WaybarPeek()
+    app.run()

--- a/scripts/waybar_peek.py
+++ b/scripts/waybar_peek.py
@@ -37,7 +37,7 @@ class WaybarPeek:
     def __init__(self):
         self.xdg_runtime = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
         self.hypr_sig = os.environ.get("HYPRLAND_INSTANCE_SIGNATURE", "")
-        self.socket_path = f"{self.xdg_runtime}/hypr/{self.hypr_sig}/.socket.sock"
+        self.socket_path = self._resolve_socket_path()
 
         self.cursor_at_top = False
         self.last_visibility = None
@@ -61,22 +61,44 @@ class WaybarPeek:
             # When re-enabled, force state recalculation
             self.last_visibility = None
 
+    def _resolve_socket_path(self) -> str:
+        """Resolve Hyprland command socket path from env or runtime dir."""
+        if self.hypr_sig:
+            p = Path(f"{self.xdg_runtime}/hypr/{self.hypr_sig}/.socket.sock")
+            if p.exists():
+                return str(p)
+
+        hypr_dir = Path(self.xdg_runtime) / "hypr"
+        try:
+            candidates = [d / ".socket.sock" for d in hypr_dir.iterdir() if d.is_dir() and (d / ".socket.sock").exists()]
+            if candidates:
+                # Prefer most recently modified socket (active session)
+                candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+                return str(candidates[0])
+        except Exception:
+            pass
+
+        return f"{self.xdg_runtime}/hypr/{self.hypr_sig}/.socket.sock"
+
     def hypr_query(self, cmd: str) -> str:
         """Query Hyprland via socket"""
-        try:
-            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            sock.connect(self.socket_path)
-            sock.send(cmd.encode())
-            response = b""
-            while True:
-                chunk = sock.recv(4096)
-                if not chunk:
-                    break
-                response += chunk
-            sock.close()
-            return response.decode()
-        except Exception:
-            return ""
+        for _ in range(2):
+            try:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(self.socket_path)
+                sock.send(cmd.encode())
+                response = b""
+                while True:
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        break
+                    response += chunk
+                sock.close()
+                return response.decode()
+            except Exception:
+                # Try to recover when service starts before env is imported
+                self.socket_path = self._resolve_socket_path()
+        return ""
 
     def get_cursor_pos(self) -> tuple:
         """Get cursor position as (x, y)"""


### PR DESCRIPTION
- **enable waybar with home-manager systemd service**
- **add JetBrains Mono Nerd Font system-wide on nemesis**
- **replace waybar demo config with minimal clock-only setup**
- **add SUPER_L and SUPER_R release binds to toggle waybar**
- **set waybar to overlay mode without reserving screen space**
- **style waybar clock pill and pin JetBrains Mono font**
- **waybar: switch clock to monocraft and tune size**
- **waybar: add vendored waybar_peek service with env tuning**
- **waybar: add power menu module and keep bar interactive**
- **waybar: refine power menu spacing and highlight styling**
- **waybar: set reboot action to Windows 11 boot entry**
